### PR TITLE
fix: clarify contexts help text

### DIFF
--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -89,7 +89,7 @@ func main() {
 	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|mistral|deepseek|openrouter|together|ollama|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")
 	root.PersistentFlags().StringVar(&kubeCtx, "context", "", "kubeconfig context")
-	root.PersistentFlags().StringVar(&kubeCtxs, "contexts", "", "comma-separated contexts for read-only fan-out (aliases ok)")
+	root.PersistentFlags().StringVar(&kubeCtxs, "contexts", "", "comma-separated contexts for read fan-out / per-context mutate (aliases ok)")
 	root.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "default namespace")
 	root.PersistentFlags().StringVarP(&outputFmt, "output", "o", "text", "output format: text|json")
 	root.PersistentFlags().StringVar(&theme, "theme", "", "color theme: auto|dracula|nord|gruvbox|mono|none")


### PR DESCRIPTION
Fixes #6.

## What changed

- Updated the `--contexts` Cobra help text to describe both read fan-out and per-context mutate when explicitly approved.
- Kept the wording aligned with the README flags table, which already documents `read fan-out / per-context mutate`.

## Why

The old CLI help said `read-only fan-out`, but the documented behavior also supports multi-context mutating runs through per-context confirmation or `--approve-each-context`. This made `kprompt --help` contradict the README and multi-cluster docs.

## Validation

- `PATH=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/.toolchains/go1.25.7/bin:$PATH go run ./cmd/kprompt --help`
- `PATH=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/.toolchains/go1.25.7/bin:$PATH go test ./...`
- `PATH=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/.toolchains/go1.25.7/bin:$PATH go build -o bin/kprompt ./cmd/kprompt`
- `PATH=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/.toolchains/go1.25.7/bin:$PATH gofmt -w cmd/kprompt/main.go`
- `git diff --check`

Note: CI uses Go 1.23.x; this local environment had Go available through the workspace toolchain rather than on the default PATH, so the commands above use that toolchain explicitly.
