### PR TITLE
docs: add theme flag and configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ kprompt config
 kprompt config set provider gemini
 kprompt config set model gemini-2.0-flash
 kprompt config set namespace default
+kprompt config set theme nord
 
 # Cluster aliases (short name → kubeconfig context)
 kprompt config alias set prod gke_myproj_us-central1_prod
@@ -257,6 +258,7 @@ Cluster / kubeconfig failures print short actionable hints (missing config, bad 
 | `--context` | kubeconfig context |
 | `--contexts` | Comma-separated contexts for read fan-out / per-context mutate |
 | `--namespace` / `-n` | Default namespace |
+| `--theme` | Output theme (`auto`, `dracula`, `gruvbox`, `mono`, `nord`, `none`) |
 
 ## Architecture
 
@@ -272,7 +274,7 @@ Package layout matches the private architecture ADRs (`cmd/kprompt`, `internal/{
 | Community | [Discussions](https://github.com/kprompt/kprompt/discussions) · [Contributing](./CONTRIBUTING.md) · [Good first issues](https://github.com/kprompt/kprompt/labels/good%20first%20issue) |
 | Social | [X @kpromptai](https://x.com/kpromptai) · [LinkedIn](https://www.linkedin.com/company/kprompt) · [Bluesky](https://bsky.app/profile/kprompt.bsky.social) · [hello@kprompt.ai](mailto:hello@kprompt.ai) |
 | Compare | [vs kubectl-ai](https://kprompt.ai/blog/kprompt-vs-kubectl-ai) · [AI tools map](https://kprompt.ai/blog/kubernetes-ai-tools-comparison) · [kubectl vs K9s](https://kprompt.ai/blog/kubectl-vs-k9s) |
-| Product | [audit](./docs/audit.md) · [impact](./docs/impact.md) · [optimize my cluster](https://kprompt.ai/blog/optimize-my-cluster) · [PlanResult JSON](https://kprompt.ai/blog/planresult-json-deep-dive) · [AI SRE](https://kprompt.ai/blog/ai-sre-not-ai-kubectl) |
+| Product | [audit](./docs/audit.md) · [impact](./docs/impact.md) · [themes](./docs/theme.md) · [optimize my cluster](https://kprompt.ai/blog/optimize-my-cluster) · [PlanResult JSON](https://kprompt.ai/blog/planresult-json-deep-dive) · [AI SRE](https://kprompt.ai/blog/ai-sre-not-ai-kubectl) |
 
 ## Contributors
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,0 +1,48 @@
+# Themes
+
+kprompt supports built-in terminal themes for human-readable output.
+
+## Select a theme
+
+Use a one-off flag:
+
+```bash
+kprompt --theme nord "list pods"
+```
+
+Set a persistent preference:
+
+```bash
+kprompt config set theme nord
+```
+
+Or use an environment variable:
+
+```bash
+export KPROMPT_THEME=dracula
+```
+
+Available theme names:
+
+- `auto`
+- `dracula`
+- `nord`
+- `gruvbox`
+- `mono`
+- `none`
+
+## Color overrides
+
+Disable ANSI color entirely:
+
+```bash
+export NO_COLOR=1
+```
+
+Force color even when output is not a TTY:
+
+```bash
+export KPROMPT_FORCE_COLOR=1
+```
+
+`auto` is the default. When no explicit theme is set, kprompt falls back to `KPROMPT_THEME`, then `auto`.


### PR DESCRIPTION
Closes #4

## Summary
- add `--theme` to the README flags table
- mention `kprompt config set theme nord` in Quick start
- add `docs/theme.md` for available themes and env overrides
- link theme docs from the README

## Testing
- docs only