### PR TITLE
test(tools): cover detect helper output

### DIFF
--- a/internal/tools/certmanager/detect_test.go
+++ b/internal/tools/certmanager/detect_test.go
@@ -1,0 +1,47 @@
+package certmanager
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "Certificate CRD not found (cert-manager.io/Certificate)",
+		},
+		{
+			name: "installed with version",
+			av: Availability{
+				Installed: true,
+				Group:     CertificateGroup,
+				Kind:      CertificateKind,
+				Versions:  []string{"v1"},
+			},
+			want: "cert-manager Certificate CRD present (cert-manager.io/Certificate: v1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	if !strings.Contains(strings.ToLower(hint), "cert-manager") {
+		t.Fatalf("InstallHint() = %q, want cert-manager reference", hint)
+	}
+}

--- a/internal/tools/gateway/detect_test.go
+++ b/internal/tools/gateway/detect_test.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "Gateway CRD not found (gateway.networking.k8s.io/Gateway)",
+		},
+		{
+			name: "installed with version",
+			av: Availability{
+				Installed: true,
+				Group:     GatewayGroup,
+				Kind:      GatewayKind,
+				Versions:  []string{"v1"},
+			},
+			want: "Gateway API Gateway CRD present (gateway.networking.k8s.io/Gateway: v1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	if !strings.Contains(strings.ToLower(hint), "gateway api") {
+		t.Fatalf("InstallHint() = %q, want Gateway API reference", hint)
+	}
+}

--- a/internal/tools/linkerd/detect_test.go
+++ b/internal/tools/linkerd/detect_test.go
@@ -1,0 +1,47 @@
+package linkerd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "Linkerd Server CRD not found (policy.linkerd.io/Server)",
+		},
+		{
+			name: "installed with version",
+			av: Availability{
+				Installed: true,
+				Group:     ServerGroup,
+				Kind:      ServerKind,
+				Versions:  []string{"v1beta3"},
+			},
+			want: "Linkerd Server CRD present (policy.linkerd.io/Server: v1beta3)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	if !strings.Contains(strings.ToLower(hint), "linkerd") {
+		t.Fatalf("InstallHint() = %q, want Linkerd reference", hint)
+	}
+}


### PR DESCRIPTION
## Summary
- cover installed and not-installed detail labels for cert-manager, Gateway API, and Linkerd
- verify each install hint is non-empty and names the expected project
- keep the change tests-only

## Testing
- `go test -count=1 ./internal/tools/certmanager/... ./internal/tools/gateway/... ./internal/tools/linkerd/...`
- `go build -p 1 -o <temporary-path> ./cmd/kprompt`

`go test -p 1 ./...` reaches two existing Windows-specific failures in `internal/config`; the affected tool packages pass.

Fixes #23