### PR TITLE
docs: add Cobra examples for doctor contexts and history

### DIFF
--- a/cmd/kprompt/contexts.go
+++ b/cmd/kprompt/contexts.go
@@ -16,6 +16,8 @@ func newContextsCmd() *cobra.Command {
 		Aliases: []string{"context", "ctx"},
 		Short:   "List kubeconfig contexts and local aliases",
 		Long:    "Shows kubeconfig contexts, which are current, and aliases from ~/.kprompt/config.yaml. Optional --check probes API reachability per context.",
+		Example: `  kprompt contexts
+  kprompt contexts --check`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rep, err := contexts.List(cmd.Context(), contexts.Options{
 				CheckReachability: check,

--- a/cmd/kprompt/doctor.go
+++ b/cmd/kprompt/doctor.go
@@ -17,6 +17,8 @@ func newDoctorCmd() *cobra.Command {
 		Use:   "doctor",
 		Short: "Check local setup (kube, LLM key, tools, Team)",
 		Long:  "Runs read-only health checks. Does not print API keys. Exit code 1 if a required check fails.",
+		Example: `  kprompt doctor
+  kprompt doctor --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rep, err := doctor.Run(cmd.Context(), doctor.Options{Context: kubeCtx})
 			if err != nil {

--- a/cmd/kprompt/history.go
+++ b/cmd/kprompt/history.go
@@ -38,7 +38,9 @@ func newHistoryCmd() *cobra.Command {
 		Use:   "rerun [index]",
 		Short: "Re-run a history prompt (default: newest)",
 		Long:  "Replays the stored prompt through the normal pipeline. Use --approve for mutations.",
-		Args:  cobra.MaximumNArgs(1),
+		Example: `  kprompt history rerun
+  kprompt history rerun 3 --approve`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			idx := 1
 			if len(args) == 1 {


### PR DESCRIPTION
Fixes #10

## Summary

Add missing `Example` fields for the `doctor`, `contexts`, and `history rerun` Cobra commands.

The examples follow the CLI usage already documented in the README and improve the generated `--help` output. No behavior changes.

## Test plan

- [x] `go test ./...`
- [x] Verified `go run ./cmd/kprompt doctor --help`
- [x] Verified `go run ./cmd/kprompt contexts --help`

Note: `go run ./cmd/kprompt history rerun --help` currently panics because of a pre-existing `-n` shorthand flag conflict. This issue is unrelated to this documentation change.