### PR TITLE
fix: clarify kprompt learn --show header

### DIFF
--- a/cmd/kprompt/learn.go
+++ b/cmd/kprompt/learn.go
@@ -80,9 +80,13 @@ func displayCtx(name string) string {
 func printLearnProfile(cmd *cobra.Command, p learn.Profile, saved bool) error {
 	out := cmd.OutOrStdout()
 	if saved {
-		fmt.Fprintf(out, "Learned cluster tool profile → %s\n\n", learn.MustPath(p.Context))
+		fmt.Fprintf(out,
+			"Learned and saved cluster tool profile → %s\n\n",
+			learn.MustPath(p.Context))
 	} else {
-		fmt.Fprintf(out, "Saved cluster tool profile (%s)\n\n", learn.MustPath(p.Context))
+		fmt.Fprintf(out,
+			"Showing saved cluster tool profile → %s\n\n",
+			learn.MustPath(p.Context))
 	}
 	fmt.Fprintln(out, p.Summary())
 	fmt.Fprintln(out)

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -14,6 +14,8 @@ kprompt "learn cluster tools"
 kprompt "detect tools"
 ```
 
+`kprompt learn --show` is read-only: it shows the saved profile without re-detecting or rewriting it.
+
 Profile path: `~/.kprompt/profiles/<context>.json` (or `$KPROMPT_HOME/profiles/`).
 
 ## What it detects


### PR DESCRIPTION
## Summary
Fix the misleading header shown by `kprompt learn --show`.

Previously, the command displayed a “Saved cluster tool profile” message even though it only read the existing profile.

## Changes
- update `kprompt learn --show` output to clearly indicate read-only display
- keep `kprompt learn` output as a distinct learned/saved message
- add a docs note explaining that `--show` does not rewrite the profile

## Test plan
- `go test ./...`
- `go build -o ./bin/kprompt ./cmd/kprompt`
- `./bin/kprompt learn`
- `./bin/kprompt learn --show`
- `./bin/kprompt learn --show --json`

Fixes #24