### PR TITLE
fix: update doctor Helm setup hint

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -188,7 +188,7 @@ func checkToolsSummary(reg *tools.Registry) []Check {
 		default:
 			c.Status = Warn
 			if c.Hint == "" {
-				c.Hint = "Optional for chart installs. Coming soon: kprompt setup (T-061+)."
+				c.Hint = "Optional for chart installs. Plan installation with: kprompt setup --profile minimal"
 			}
 		}
 		out = append(out, c)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -49,6 +49,9 @@ func TestRunLLMKeyRequired(t *testing.T) {
 	if helm.Status != Warn {
 		t.Fatalf("helm=%+v", helm)
 	}
+	if helm.Hint != "Optional for chart installs. Plan installation with: kprompt setup --profile minimal" {
+		t.Fatalf("helm hint=%q", helm.Hint)
+	}
 	teamChk := find(rep, "team")
 	if teamChk.Status != Skip {
 		t.Fatalf("team=%+v", teamChk)


### PR DESCRIPTION
## Summary

- replace the stale Helm “coming soon” doctor hint with the shipped `kprompt setup --profile minimal` command
- remove the internal ticket reference from the public hint
- assert the exact user-facing hint in the existing doctor test

## Why

`kprompt setup` already ships, so the fallback doctor guidance was both inaccurate and exposed an internal ticket identifier. The new hint points users to the existing dry-run setup path without changing setup behavior.

Fixes #34.

## Validation

- `go test ./internal/doctor`
- `go test ./...`
- `go build ./cmd/kprompt`
- `git diff --check`

## AI disclosure

OpenAI Codex assisted with repository research, the focused edit, and validation. I reviewed the final diff and test results before publishing.
