### PR TITLE
fix: remove ticket ID from GitOps PR body

### DIFF
--- a/internal/gitopspr/gitopspr.go
+++ b/internal/gitopspr/gitopspr.go
@@ -282,7 +282,7 @@ func prTitle(plan planner.ExecutionPlan, prompt string) string {
 
 func prBody(plan planner.ExecutionPlan, prompt string, files []FileChange) string {
 	var b strings.Builder
-	b.WriteString("## kprompt GitOps PR (T-072)\n\n")
+	b.WriteString("## kprompt GitOps PR\n\n")
 	b.WriteString("This pull request was opened **instead of applying to the cluster**.\n\n")
 	if p := strings.TrimSpace(prompt); p != "" {
 		fmt.Fprintf(&b, "**Prompt:** %s\n\n", p)

--- a/internal/gitopspr/gitopspr_test.go
+++ b/internal/gitopspr/gitopspr_test.go
@@ -98,6 +98,9 @@ func TestOpenFromPlanMemRunner(t *testing.T) {
 	if !strings.Contains(mem.LastBody, "instead of applying") {
 		t.Fatalf("body=%q", mem.LastBody)
 	}
+	if strings.Contains(mem.LastBody, "T-072") {
+		t.Fatalf("body contains internal ticket ID: %q", mem.LastBody)
+	}
 }
 
 func TestOpenFromPlanRequiresRepo(t *testing.T) {


### PR DESCRIPTION
## Summary

- remove the internal `T-072` identifier from generated GitOps PR headings
- add a regression assertion that generated PR bodies do not expose the ticket ID

## Why

Every PR generated through `--gitops` included an internal roadmap identifier in its public Markdown heading. Removing it at `prBody` keeps generated output user-facing without changing GitOps behavior.

Fixes #36.

## Validation

- `go test ./internal/gitopspr`
- `go test ./...`
- `go build -o /tmp/kprompt-issue-36 ./cmd/kprompt`
- `git diff --check`
