### PR TITLE
fix: strip ticket IDs from setup plan stdout (not just --help)

### DIFF
--- a/internal/setup/cluster.go
+++ b/internal/setup/cluster.go
@@ -166,7 +166,7 @@ func ApplyCluster(ctx context.Context, plan Plan, opts ClusterApplyOptions, out 
 		opts.Runner = DefaultRunner{}
 	}
 	rep := ClusterApplyReport{Notes: []string{
-		"Cluster apply only installs operators (T-064). Wipe-class uninstalls are denied.",
+		"Cluster apply only installs operators. Wipe-class uninstalls are denied.",
 		fmt.Sprintf("Namespace defaults: Argo=%s · Prometheus stack=%s",
 			orDefault(opts.ArgoNS, DefaultArgoNamespace),
 			orDefault(opts.PromNS, DefaultPrometheusNamespace)),
@@ -332,7 +332,7 @@ func FormatClusterApply(w io.Writer, rep ClusterApplyReport) {
 // NamespaceDefaultsDoc documents install namespaces.
 func NamespaceDefaultsDoc() string {
 	return fmt.Sprintf(
-		"Cluster install namespaces (T-064):\n  Argo Workflows → %s\n  kube-prometheus-stack → %s (release %s)\n",
+		"Cluster install namespaces:\n  Argo Workflows → %s\n  kube-prometheus-stack → %s (release %s)\n",
 		DefaultArgoNamespace, DefaultPrometheusNamespace, DefaultPrometheusRelease,
 	)
 }

--- a/internal/setup/host.go
+++ b/internal/setup/host.go
@@ -54,9 +54,9 @@ func (DefaultRunner) GOOS() string    { return runtime.GOOS }
 
 // InstallMethod is how we would install a host binary on this OS.
 type InstallMethod struct {
-	ID          string   // brew | get-helm-3 | unsupported
+	ID          string // brew | get-helm-3 | unsupported
 	Description string
-	Binary      string   // expected PATH name after install
+	Binary      string // expected PATH name after install
 	Prepare     func(ctx context.Context, r CommandRunner) (name string, args []string, cleanup func(), err error)
 }
 
@@ -99,7 +99,7 @@ func ResolveHelmMethod(r CommandRunner) (InstallMethod, error) {
 	default:
 		return InstallMethod{
 			ID:          "unsupported",
-			Description: fmt.Sprintf("%s is not in the T-063 OS matrix — install Helm manually: https://helm.sh/docs/intro/install/", goos),
+			Description: fmt.Sprintf("%s is not in the supported OS matrix — install Helm manually: https://helm.sh/docs/intro/install/", goos),
 			Binary:      "helm",
 		}, nil
 	}
@@ -153,7 +153,7 @@ func ApplyHost(ctx context.Context, plan Plan, r CommandRunner, out io.Writer) (
 		r = DefaultRunner{}
 	}
 	rep := ApplyReport{Notes: []string{
-		"Host apply only (T-063). Cluster operators remain T-064; URL config stays manual / config set.",
+		"Host apply only. Cluster operators remain a separate step; URL config stays manual / config set.",
 	}}
 	needed := HostNeeded(plan)
 	if len(needed) == 0 {
@@ -166,7 +166,7 @@ func ApplyHost(ctx context.Context, plan Plan, r CommandRunner, out io.Writer) (
 			rep.Applied = append(rep.Applied, HostResult{
 				Component: step.Component,
 				Status:    "unsupported",
-				Detail:    "T-063 installs Helm only; other host CLIs are not wired yet",
+				Detail:    "Setup currently installs Helm only; other host CLIs are not wired yet",
 			})
 			continue
 		}
@@ -261,10 +261,10 @@ func FormatApply(w io.Writer, rep ApplyReport) {
 // OSMatrixDoc is the supported install matrix for docs / --help.
 func OSMatrixDoc() string {
 	var b strings.Builder
-	b.WriteString("Host install OS matrix (T-063):\n")
+	b.WriteString("Host install OS matrix:\n")
 	b.WriteString("  darwin  — Homebrew: brew install helm (brew required)\n")
 	b.WriteString("  linux   — brew if present, else official get-helm-3 script (curl required)\n")
 	b.WriteString("  other   — unsupported; install manually (https://helm.sh/docs/intro/install/)\n")
-	b.WriteString("Skip if helm already on PATH. Cluster installs are T-064.\n")
+	b.WriteString("Skip if helm already on PATH. Cluster installs are a separate step.\n")
 	return b.String()
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -94,7 +94,7 @@ func BuildPlan(reg *tools.Registry, opts Options) (Plan, error) {
 		Steps:   make([]Step, 0, 8),
 		Notes: []string{
 			"Plan from tools.Detect (ADR-0018). Default is dry-run.",
-			"Apply with --approve / TTY: host Helm (T-063) + cluster Argo/Prom stack (T-064).",
+			"Apply with --approve / TTY: host Helm + cluster Argo/Prom stack.",
 			"Wipe-class uninstalls denied. Re-check: kprompt tools · kprompt doctor",
 		},
 	}
@@ -309,7 +309,7 @@ func FormatText(w io.Writer, plan Plan) error {
 		}
 	}
 	if plan.Needed > 0 {
-		fmt.Fprintln(w, "\nNo mutations performed yet. Apply host+cluster with --approve or TTY confirm (T-063/T-064).")
+		fmt.Fprintln(w, "\nNo mutations performed yet. Apply host+cluster with --approve or TTY confirm.")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- remove internal ticket IDs from user-facing setup runtime text
- scrub setup JSON notes as well
- leave Cobra help text in `cmd/kprompt/setup.go` unchanged; tracked separately in #22

Closes #37

## Verification

- `go build ./...`
- `go test ./internal/setup -v`
- `go build -o ./bin/kprompt ./cmd/kprompt`
- `./bin/kprompt setup`
- `./bin/kprompt setup --profile full`
- `./bin/kprompt setup --json`