### PR TITLE
feat(llm): add xAI (Grok) provider preset (P-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ export KPROMPT_OPENAI_API_KEY=sk-...          # --provider openai (default)
 export KPROMPT_ANTHROPIC_API_KEY=sk-ant-...   # --provider anthropic
 export KPROMPT_GEMINI_API_KEY=...             # --provider gemini
 export KPROMPT_GROQ_API_KEY=...               # --provider groq
+export KPROMPT_XAI_API_KEY=...                # --provider xai (Grok)
 export KPROMPT_MOONSHOT_API_KEY=...           # --provider moonshot (Kimi K3)
 # local: kprompt --provider ollama --model llama3.2 "..."
 ```

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -102,7 +102,7 @@ func main() {
 	root.PersistentFlags().BoolVar(&approveEachContext, "approve-each-context", false, "apply a mutating plan to every --contexts entry (explicit; not implied by --approve)")
 	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment rollout to complete")
 	root.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for --wait (default 5m)")
-	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|mistral|deepseek|moonshot|openrouter|together|ollama|openai-compatible)")
+	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|mistral|deepseek|moonshot|openrouter|together|ollama|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")
 	root.PersistentFlags().StringVar(&kubeCtx, "context", "", "kubeconfig context")
 	root.PersistentFlags().StringVar(&kubeCtxs, "contexts", "", "comma-separated contexts for read fan-out / per-context mutate (aliases ok)")

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,6 +10,7 @@ API keys are **environment variables only** (never stored in the config file).
 | Anthropic | `anthropic` | `KPROMPT_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY` | `claude-sonnet-4-20250514` | Messages API |
 | Google Gemini | `gemini` | `KPROMPT_GEMINI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` | `gemini-2.0-flash` | AI Studio key |
 | Groq | `groq` | `KPROMPT_GROQ_API_KEY` / `GROQ_API_KEY` | `llama-3.3-70b-versatile` | OpenAI-compatible |
+| xAI (Grok) | `xai` | `KPROMPT_XAI_API_KEY` / `XAI_API_KEY` | `grok-4.5` | OpenAI-compatible |
 | Mistral | `mistral` | `KPROMPT_MISTRAL_API_KEY` / `MISTRAL_API_KEY` | `mistral-small-latest` | OpenAI-compatible |
 | DeepSeek | `deepseek` | `KPROMPT_DEEPSEEK_API_KEY` / `DEEPSEEK_API_KEY` | `deepseek-chat` | OpenAI-compatible |
 | Moonshot (Kimi K3) | `moonshot` | `KPROMPT_MOONSHOT_API_KEY` / `MOONSHOT_API_KEY` | `kimi-k3` | OpenAI-compatible |
@@ -36,6 +37,10 @@ kprompt --provider gemini --model gemini-2.0-flash "deploy redis"
 # Groq
 export KPROMPT_GROQ_API_KEY=...
 kprompt --provider groq "scale api to 3"
+
+# xAI / Grok
+export KPROMPT_XAI_API_KEY=...
+kprompt --provider xai "explain why api is crashlooping"
 
 # Moonshot / Kimi K3
 export KPROMPT_MOONSHOT_API_KEY=...

--- a/internal/llm/presets.go
+++ b/internal/llm/presets.go
@@ -56,6 +56,14 @@ var Presets = []Preset{
 		HelpURL:      "https://console.groq.com/keys",
 	},
 	{
+		Name:         "xai",
+		Kind:         "openai",
+		BaseURL:      "https://api.x.ai/v1",
+		DefaultModel: "grok-4.5",
+		EnvKeys:      []string{"KPROMPT_XAI_API_KEY", "XAI_API_KEY"},
+		HelpURL:      "https://console.x.ai/",
+	},
+	{
 		Name:         "mistral",
 		Kind:         "openai",
 		BaseURL:      "https://api.mistral.ai/v1",

--- a/internal/llm/presets_test.go
+++ b/internal/llm/presets_test.go
@@ -16,10 +16,9 @@ func TestLookupPresetDefaults(t *testing.T) {
 		t.Fatal("ollama should allow empty key")
 	}
 }
-
 func TestSupportedNamesIncludesNewProviders(t *testing.T) {
 	s := SupportedNames()
-	for _, want := range []string{"openai", "anthropic", "gemini", "groq", "mistral", "deepseek", "moonshot", "ollama", "openrouter", "together"} {
+	for _, want := range []string{"openai", "anthropic", "gemini", "groq", "mistral", "deepseek", "moonshot", "ollama", "openrouter", "together", "xai"} {
 		if !contains(s, want) {
 			t.Fatalf("%q missing from %s", want, s)
 		}

--- a/internal/llm/presets_test.go
+++ b/internal/llm/presets_test.go
@@ -16,6 +16,24 @@ func TestLookupPresetDefaults(t *testing.T) {
 		t.Fatal("ollama should allow empty key")
 	}
 }
+func TestLookupPresetXAI(t *testing.T) {
+	p, ok := LookupPreset("xai")
+	if !ok {
+		t.Fatal("xai preset not found")
+	}
+	if p.Kind != "openai" {
+		t.Fatalf("xai kind = %q, want openai", p.Kind)
+	}
+	if p.BaseURL != "https://api.x.ai/v1" {
+		t.Fatalf("xai base URL = %q", p.BaseURL)
+	}
+	if p.DefaultModel != "grok-4.5" {
+		t.Fatalf("xai default model = %q", p.DefaultModel)
+	}
+	if len(p.EnvKeys) != 2 || p.EnvKeys[0] != "KPROMPT_XAI_API_KEY" || p.EnvKeys[1] != "XAI_API_KEY" {
+		t.Fatalf("xai env keys = %v", p.EnvKeys)
+	}
+}
 func TestSupportedNamesIncludesNewProviders(t *testing.T) {
 	s := SupportedNames()
 	for _, want := range []string{"openai", "anthropic", "gemini", "groq", "mistral", "deepseek", "moonshot", "ollama", "openrouter", "together", "xai"} {


### PR DESCRIPTION
## Summary

Implements the public `kprompt` repo portion of #52 by adding an `xai` provider preset for xAI Grok via the existing OpenAI-compatible adapter.

This PR covers:
- preset registration
- supported provider test update
- `--provider` CLI help text
- `docs/providers.md`
- `README.md`

Out of scope for this repo:
- `kprompt-api`
- `kprompt-app`
- architecture checklist/docs in private repos
- website docs updates (will be submitted separately in `kprompt-website`)

## Changes

- add `xai` preset:
  - kind: `openai`
  - base URL: `https://api.x.ai/v1`
  - default model: `grok-4.5`
  - env keys: `KPROMPT_XAI_API_KEY`, `XAI_API_KEY`
- add `xai` to supported provider names / CLI help
- document `xai` usage in provider docs and README

## Test plan

- [x] `go test ./internal/llm`
- [x] Added `TestLookupPresetXAI`