### PR TITLE
docs(readme): add setup and learning examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ kprompt history rerun 3 --approve
 
 History stores prompt, kind, summary, and action refs — never manifests or API keys.
 
+Explore setup, the learn profile, and built-in recipes:
+
+```bash
+kprompt setup
+kprompt learn
+kprompt recipe list
+```
+
 Use `kprompt doctor` after install to verify kubeconfig, LLM keys, integrations, and optional Team enrollment.
 
 ```bash


### PR DESCRIPTION
## Summary

- add runnable examples for guided setup and environment learning
- show how to list the built-in recipe packs
- keep the examples beside the existing History/post-install commands

Fixes #40

## Validation

- `go run ./cmd/kprompt setup --help`
- `go run ./cmd/kprompt learn --help`
- `go run ./cmd/kprompt recipe list --help`
- confirmed `docs/setup.md`, `docs/learn.md`, and `docs/recipes.md` still exist
- `git diff --check`
