### PR TITLE
fix: drift SuggestedPlanHint claims GitOps PR mode is not shipped

### DIFF
--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -2,7 +2,7 @@
 //
 // The MVP reads Flux Kustomization / Argo CD Application sync+health via
 // tools/gitops and emits ADR-0014 Investigation findings. It never mutates.
-// Approve-gated sync plans may be offered separately (pairs T-043; PR mode is T-072).
+// Approve-gated sync plans may be offered separately (pairs T-043).
 package drift
 
 import (
@@ -92,7 +92,7 @@ func (a *Analyzer) Run(ctx context.Context, req Request) (incident.Investigation
 		})
 		out.Summary = "GitOps controllers not available — drift scan degraded"
 		out.Confidence = 0.95
-		out.SuggestedPlanHint = "Install Flux or Argo CD, then re-run: kprompt \"check drift\". Optional PR mode is tracked as T-072."
+		out.SuggestedPlanHint = "Install Flux or Argo CD, then re-run: kprompt \"check drift\". For PR mode, see docs/gitops-pr.md and use kprompt --gitops --gitops-repo owner/name \"...\"."
 		sortFindings(&out)
 		if err := incident.ValidateInvestigation(out); err != nil {
 			return out, err
@@ -207,7 +207,7 @@ func (a *Analyzer) Run(ctx context.Context, req Request) (incident.Investigation
 		out.Confidence = 0.9
 		out.RootCause = "Live cluster state differs from the GitOps desired revision (manual change, failed sync, or pending reconcile)"
 	}
-	out.SuggestedPlanHint = "Review findings; approve a GitOps sync to reconcile, or open a PR (T-072 PR mode not shipped yet). Drift never auto-syncs."
+	out.SuggestedPlanHint = "Review findings; approve a GitOps sync to reconcile, or open a PR with kprompt --gitops --gitops-repo owner/name \"...\". See docs/gitops-pr.md. Drift never auto-syncs."
 
 	sortFindings(&out)
 	if err := incident.ValidateInvestigation(out); err != nil {

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -61,6 +61,12 @@ func TestRunGitOpsMissing(t *testing.T) {
 	if len(inv.Degraded) == 0 || inv.Degraded[0] != "gitops" {
 		t.Fatalf("degraded=%v", inv.Degraded)
 	}
+	if !strings.Contains(inv.SuggestedPlanHint, "docs/gitops-pr.md") || !strings.Contains(inv.SuggestedPlanHint, "--gitops --gitops-repo") {
+		t.Fatalf("suggested hint=%q", inv.SuggestedPlanHint)
+	}
+	if strings.Contains(inv.SuggestedPlanHint, "T-072") || strings.Contains(inv.SuggestedPlanHint, "not shipped") {
+		t.Fatalf("stale suggested hint=%q", inv.SuggestedPlanHint)
+	}
 }
 
 func TestRunResourceDrifts(t *testing.T) {
@@ -112,5 +118,11 @@ func TestRunClean(t *testing.T) {
 	}
 	if !strings.Contains(inv.Summary, "No drift") {
 		t.Fatalf("summary=%q", inv.Summary)
+	}
+	if !strings.Contains(inv.SuggestedPlanHint, "--gitops --gitops-repo") || !strings.Contains(inv.SuggestedPlanHint, "docs/gitops-pr.md") {
+		t.Fatalf("suggested hint=%q", inv.SuggestedPlanHint)
+	}
+	if strings.Contains(inv.SuggestedPlanHint, "T-072") || strings.Contains(inv.SuggestedPlanHint, "not shipped") {
+		t.Fatalf("stale suggested hint=%q", inv.SuggestedPlanHint)
 	}
 }

--- a/internal/suggest/drift.go
+++ b/internal/suggest/drift.go
@@ -12,7 +12,7 @@ import (
 )
 
 // FromDrift turns Drift.OutOfSync findings into approve-gated GitOps sync plans
-// plus guidance for unhealthy apps, resource-level diffs, and PR mode (T-072).
+// plus guidance for unhealthy apps, resource-level diffs, and PR mode.
 func FromDrift(inv incident.Investigation) ([]Suggestion, error) {
 	var out []Suggestion
 	seenSync := map[string]bool{}
@@ -50,12 +50,12 @@ func FromDrift(inv incident.Investigation) ([]Suggestion, error) {
 			addDriftGuidance(&out, seenGuide, f.Code,
 				"Resource differs from Git",
 				guidancePrompt(ref, "investigate"),
-				"Per-resource OutOfSync entries are reported from Argo inventory — reconcile via app sync or fix Git (PR mode is T-072)")
+				"Per-resource OutOfSync entries are reported from Argo inventory — reconcile via app sync or fix Git with kprompt --gitops --gitops-repo owner/name \"...\"")
 		case drift.CodeMissing:
 			addDriftGuidance(&out, seenGuide, f.Code,
 				"Install GitOps to enable drift",
 				"learn cluster tools",
-				"Install Flux or Argo CD, then re-run drift. Optional: kprompt --gitops opens a PR (T-072) once gitops.repo is set")
+				"Install Flux or Argo CD, then re-run drift. For PR mode, see docs/gitops-pr.md and use kprompt --gitops --gitops-repo owner/name \"...\"")
 		}
 	}
 
@@ -63,7 +63,7 @@ func FromDrift(inv incident.Investigation) ([]Suggestion, error) {
 		addDriftGuidance(&out, seenGuide, "Drift.PRMode",
 			"Prefer a Git PR instead of live sync?",
 			"gitops pr mode",
-			"Live sync reconciles toward Git desired state. Prefer --gitops to open a PR instead of cluster mutate (T-072)")
+			"Live sync reconciles toward Git desired state. Prefer kprompt --gitops --gitops-repo owner/name \"...\" to open a PR instead of cluster mutate")
 	}
 	return out, nil
 }

--- a/internal/suggest/drift_test.go
+++ b/internal/suggest/drift_test.go
@@ -1,6 +1,7 @@
 package suggest
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/kprompt/kprompt/internal/drift"
@@ -60,5 +61,11 @@ func TestFromDriftMissingIsGuidance(t *testing.T) {
 	}
 	if len(suggestions) == 0 {
 		t.Fatal("expected guidance")
+	}
+	if !strings.Contains(suggestions[0].Summary, "docs/gitops-pr.md") && !strings.Contains(suggestions[0].Summary, "--gitops --gitops-repo") {
+		t.Fatalf("guidance=%q", suggestions[0].Summary)
+	}
+	if strings.Contains(suggestions[0].Summary, "T-072") || strings.Contains(suggestions[0].Summary, "not shipped") {
+		t.Fatalf("stale guidance=%q", suggestions[0].Summary)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #35

Updates stale drift guidance that still claims GitOps PR mode is not shipped.

## Changes

- replace outdated `SuggestedPlanHint` copy in `internal/drift`
- point users to `docs/gitops-pr.md`
- remove `T-072` / `not shipped` from user-facing drift strings
- scrub matching stale copy in `internal/suggest/drift.go`
- update tests to cover the new copy

## Test plan

- [x] `go test ./internal/drift ./internal/suggest`