### PR TITLE
fix: resolve history -n shorthand conflict

### DIFF
--- a/cmd/kprompt/history.go
+++ b/cmd/kprompt/history.go
@@ -32,7 +32,7 @@ func newHistoryCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().IntVarP(&limit, "limit", "n", 20, "number of entries to show")
+	cmd.Flags().IntVar(&limit, "limit", 20, "number of entries to show")
 
 	cmd.AddCommand(&cobra.Command{
 		Use:   "rerun [index]",


### PR DESCRIPTION
## Summary

Closes #33

Removes the local `-n` shorthand from `kprompt history --limit` so it no longer conflicts with the global `--namespace/-n` flag.

## Changes

- remove the `-n` shorthand from `kprompt history --limit`
- keep `--limit` behavior unchanged
- preserve global `-n = --namespace`

## Test plan

- [x] `go test ./cmd/kprompt ./internal/history`
- [x] `go run ./cmd/kprompt history --help`
- [x] `go run ./cmd/kprompt history rerun --help`
- [x] `go run ./cmd/kprompt history --limit 5`