### PR TITLE
docs: add Cobra Examples for setup, learn, tools, and recipe

### DIFF
--- a/cmd/kprompt/learn.go
+++ b/cmd/kprompt/learn.go
@@ -23,12 +23,18 @@ func newLearnCmd() *cobra.Command {
 integrations via tools.Detect, then writes ~/.kprompt/profiles/<context>.json.
 
 Read-only — never mutates the cluster. The profile biases later intent routing
-toward the detected stack. Re-run after installing new controllers.
-
+toward the detected stack. Re-run after installing new controllers.`,
+		Example: `  # Detect cluster tools and save profile
   kprompt learn
+
+  # Detect cluster tools on a specific kube context
   kprompt learn --context kind-dev
+
+  # Print the saved profile without re-detecting
   kprompt learn --show
-  kprompt learn --json`,
+
+  # Emit the saved profile in JSON format
+  kprompt learn --show --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			file, err := config.LoadFile()
 			if err != nil {

--- a/cmd/kprompt/recipe.go
+++ b/cmd/kprompt/recipe.go
@@ -17,12 +17,20 @@ func newRecipeCmd() *cobra.Command {
 		Use:   "recipe",
 		Short: "Curated workflow packs (harden, peak prep, Ingress→Gateway discover, RCA chains)",
 		Long: `Recipes expand into multi-step prompts run through the same route + approval
-loop as a manual "A then B" chain. Never mutates silently (S-013 · T-088).
-
+loop as a manual "A then B" chain. Never mutates silently (S-013 · T-088).`,
+		Example: `  # List all built-in recipe packs
   kprompt recipe list
+
+  # Show steps and triggers for a specific recipe
   kprompt recipe show harden-production
+
+  # Execute a recipe in a specific namespace
   kprompt recipe run harden-production -n payments
+
+  # Run an RCA chain for a crashlooping workload
   kprompt recipe run crashloop-rca --workload api -n payments
+
+  # Run via natural language trigger directly
   kprompt "prepare for black friday"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -39,6 +47,11 @@ func newRecipeListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List built-in recipe packs",
+		Example: `  # List all recipe packs as a formatted table
+  kprompt recipe list
+
+  # Output the catalog in JSON format
+  kprompt recipe list --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if jsonOut {
 				enc := json.NewEncoder(cmd.OutOrStdout())
@@ -58,6 +71,8 @@ func newRecipeShowCmd() *cobra.Command {
 		Use:   "show <id>",
 		Short: "Show one recipe (steps + notes)",
 		Args:  cobra.ExactArgs(1),
+		Example: `  # Show details of the harden-production recipe
+  kprompt recipe show harden-production`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, ok := recipe.Lookup(args[0])
 			if !ok {
@@ -80,6 +95,14 @@ func newRecipeRunCmd() *cobra.Command {
 		Use:   "run <id>",
 		Short: "Expand and execute a recipe as a multi-step route",
 		Args:  cobra.ExactArgs(1),
+		Example: `  # Run a recipe in a specific namespace
+  kprompt recipe run harden-production -n payments
+
+  # Run a recipe with workload and namespace overrides
+  kprompt recipe run crashloop-rca --workload api -n payments
+
+  # Run a recipe and automatically approve mutating steps
+  kprompt recipe run oom-rca --workload backend --approve`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, ok := recipe.Lookup(args[0])
 			if !ok {

--- a/cmd/kprompt/setup.go
+++ b/cmd/kprompt/setup.go
@@ -37,10 +37,17 @@ Profiles:
   platform  Helm + Argo Workflows + Prometheus stack (default)
   full      platform + Grafana + OpenTelemetry URL config (config lane)
 
-` + setup.OSMatrixDoc() + setup.NamespaceDefaultsDoc() + `
+` + setup.OSMatrixDoc() + "\n" + setup.NamespaceDefaultsDoc(),
+		Example: `  # Detect missing tools and print dry-run installation plan
   kprompt setup
+
+  # Approve setup with minimal profile
   kprompt setup --profile minimal --approve
+
+  # Approve setup with platform profile on a specific kube context
   kprompt setup --profile platform --approve --context kind-dev
+
+  # Generate and print the setup plan in JSON format
   kprompt setup --dry-run --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			file, err := config.LoadFile()

--- a/cmd/kprompt/tools.go
+++ b/cmd/kprompt/tools.go
@@ -20,6 +20,14 @@ func newToolsCmd() *cobra.Command {
 		Use:   "tools",
 		Short: "Show detected integrations (Helm, Argo, Prometheus, …)",
 		Long:  "Probes local binaries, configured URLs, and the active Kubernetes cluster. Read-only — does not call an LLM.",
+		Example: `  # Show integrations using the default context
+  kprompt tools
+
+  # Show integrations for a specific kube context
+  kprompt tools --context kind-dev
+
+  # Output details in JSON format
+  kprompt tools --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			file, err := config.LoadFile()
 			if err != nil {


### PR DESCRIPTION
## Summary                                                                           
                                                                                      
Adds Cobra `Example:` fields to `setup`, `learn`, `tools`, and `recipe` commands/subcommands. This moves existing example invocations out of the `Long:` description blocks and places them into the dedicated `Examples:` section in the `--help` output, enhancing readability and CLI user experience.                           

Resolves
- #38 

## Changes

- `cmd/kprompt/setup.go`: Moved examples to the `Example` field, added comments describing each, and added a newline between the host and cluster default documentation sections.
- `cmd/kprompt/learn.go`: Moved examples to the `Example` field and added comments.  
- `cmd/kprompt/tools.go`: Added a new `Example` field with comments.                 
- `cmd/kprompt/recipe.go`: Moved main command examples to the `Example` field, and added `Example` fields to `list`, `show`, and `run` subcommands.                       

## Test plan

- [x] `go test ./...` (CLI) and/or website checks as applicable (verified locally, all tests pass successfully)
- [x] Manual: relevant `kprompt` `--help` outputs verified visually to ensure correct indentation and spacing
- [x] No secrets, kubeconfigs, or API keys in the diff

## Screenshots

setup command -

<img width="852" height="551" alt="image" src="https://github.com/user-attachments/assets/0a41bddc-d9d7-4c3b-a8dc-253d71dba28a" />

learn command

<img width="789" height="328" alt="image" src="https://github.com/user-attachments/assets/22f31bb7-b269-4bf7-b5e2-ccd45789cdf1" />

recipe command

<img width="746" height="429" alt="image" src="https://github.com/user-attachments/assets/9abf0fe5-d0b5-49e5-8051-83009d33d393" />

tools command

<img width="992" height="282" alt="image" src="https://github.com/user-attachments/assets/890203f6-31f6-474f-924d-dc7784a525d9" />
