### PR TITLE
feat: add kprompt theme preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ kprompt config set provider gemini
 kprompt config set model gemini-2.0-flash
 kprompt config set namespace default
 kprompt config set theme nord
+kprompt theme preview   # sample every palette in the terminal
 
 # Cluster aliases (short name → kubeconfig context)
 kprompt config alias set prod gke_myproj_us-central1_prod

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -122,6 +122,7 @@ func main() {
 		},
 	})
 	root.AddCommand(newConfigCmd())
+	root.AddCommand(newThemeCmd())
 	root.AddCommand(newContextsCmd())
 	root.AddCommand(newDoctorCmd())
 	root.AddCommand(newDashCmd())

--- a/cmd/kprompt/theme.go
+++ b/cmd/kprompt/theme.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/kprompt/kprompt/internal/ui"
+)
+
+func newThemeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "theme",
+		Short: "Preview built-in terminal color themes",
+		Long: `Lists every built-in palette with a short color sample.
+
+Read-only — no cluster or LLM access. Does not change your saved theme;
+use --theme, "kprompt config set theme <name>", or KPROMPT_THEME to select one.`,
+		Example: `  # Preview every palette (same as theme preview)
+  kprompt theme
+
+  # Explicit preview subcommand
+  kprompt theme preview
+
+  # Use a theme for one command
+  kprompt --theme nord "list pods"`,
+		RunE: runThemePreview,
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:     "preview",
+		Short:   "Print a color sample for each built-in theme",
+		Example: `  kprompt theme preview`,
+		RunE:    runThemePreview,
+	})
+	return cmd
+}
+
+func runThemePreview(cmd *cobra.Command, _ []string) error {
+	ui.PreviewThemes(cmd.OutOrStdout())
+	return nil
+}

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -2,6 +2,15 @@
 
 kprompt supports built-in terminal themes for human-readable output.
 
+## Preview
+
+List every palette with a short color sample (no cluster or LLM key required):
+
+```bash
+kprompt theme
+kprompt theme preview
+```
+
 ## Select a theme
 
 Use a one-off flag:

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -191,6 +191,52 @@ func ThemeNames() []string {
 	return names
 }
 
+// PreviewThemes writes a demo of every built-in palette to w.
+// Colors are forced on (unless NO_COLOR is set) so the preview is useful even
+// when stdout is redirected; the "none" theme stays plain.
+func PreviewThemes(w io.Writer) {
+	forceColor := os.Getenv("NO_COLOR") == ""
+	fmt.Fprintln(w, "Built-in themes — pick one with --theme, config set theme, or KPROMPT_THEME")
+	fmt.Fprintln(w)
+	for _, name := range ThemeNames() {
+		th := paletteByName(name)
+		th.enabled = forceColor && !disableKeywords[name]
+		fmt.Fprintln(w, th.Bold(name))
+		if disableKeywords[name] {
+			fmt.Fprintln(w, "  plain output (no ANSI color)")
+			fmt.Fprintln(w)
+			continue
+		}
+		fmt.Fprintf(w, "  %s  %s  %s  %s  %s  %s  %s\n",
+			th.Heading("Intent:"),
+			th.Success("applied"),
+			th.Warn("caution"),
+			th.Danger("denied"),
+			th.Info("info"),
+			th.Accent("deploy/api"),
+			th.Muted("detail"),
+		)
+		fmt.Fprintf(w, "  risk  %s  %s  %s\n",
+			th.Risk(safety.RiskLow),
+			th.Risk(safety.RiskMedium),
+			th.Risk(safety.RiskHigh),
+		)
+		fmt.Fprintf(w, "  try   %s\n", th.Accent(fmt.Sprintf(`kprompt --theme %s "list pods"`, name)))
+		fmt.Fprintln(w)
+	}
+}
+
+func paletteByName(name string) Theme {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if disableKeywords[name] {
+		return Theme{}
+	}
+	if p, ok := palettes[name]; ok {
+		return p
+	}
+	return palettes["auto"]
+}
+
 // themeFor resolves the active theme for a writer, honoring configuration,
 // KPROMPT_THEME, NO_COLOR, KPROMPT_FORCE_COLOR, and TTY detection.
 func themeFor(w io.Writer) Theme {

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -93,3 +93,46 @@ func TestThemeNamesIncludeKnownPalettes(t *testing.T) {
 		}
 	}
 }
+
+func TestPreviewThemesListsEveryPalette(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("KPROMPT_FORCE_COLOR", "")
+	var buf bytes.Buffer
+	PreviewThemes(&buf)
+	out := buf.String()
+	for _, want := range ThemeNames() {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview missing theme %q", want)
+		}
+	}
+	if !strings.Contains(out, "plain output") {
+		t.Error("preview should describe the none theme as plain")
+	}
+	if !strings.Contains(out, `kprompt --theme nord "list pods"`) {
+		t.Error("preview should include a try hint with --theme")
+	}
+	// With colors forced for non-TTY preview, colored themes wrap ANSI.
+	if !strings.Contains(out, "\x1b[") {
+		t.Error("preview should emit ANSI when NO_COLOR is unset")
+	}
+}
+
+func TestPreviewThemesRespectsNoColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var buf bytes.Buffer
+	PreviewThemes(&buf)
+	if strings.Contains(buf.String(), "\x1b[") {
+		t.Fatal("NO_COLOR must keep theme preview plain")
+	}
+}
+
+func TestPaletteByNameNoneAndUnknown(t *testing.T) {
+	none := paletteByName("none")
+	if none.enabled || none.heading != "" {
+		t.Fatalf("none palette should be zero Theme: %+v", none)
+	}
+	fallback := paletteByName("does-not-exist")
+	if fallback.heading != palettes["auto"].heading {
+		t.Fatal("unknown palette name should fall back to auto")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `kprompt theme` / `kprompt theme preview` to demo every built-in palette (roles + risk samples + try hints)
- Force color in the preview unless `NO_COLOR` is set; `none` stays plain
- Document in `docs/theme.md` and mention in README

Fixes #81

## Test plan
- [x] `go test ./internal/ui/ ./cmd/kprompt/`
- [x] `kprompt theme preview` lists auto/dracula/gruvbox/mono/none/nord
- [x] `NO_COLOR=1 kprompt theme preview` stays plain
- [x] No cluster/LLM required


Made with [Cursor](https://cursor.com)