### PR TITLE
feat(audit): detect writable root filesystem (readOnlyRootFilesystem)

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -28,6 +28,7 @@ applies silently, and `-o json` stays report-only.
 | `Audit.MissingRequests` | missing CPU or memory requests |
 | `Audit.MissingLimits` | missing CPU or memory limits |
 | `Audit.HostNamespace` | `hostNetwork` / `hostPID` / `hostIPC` |
+| `Audit.WritableRootFS` | `readOnlyRootFilesystem` is not `true` (unset or `false`) |
 
 ```bash
 kprompt "audit payments" -n payments --output json | jq '.result'
@@ -45,12 +46,14 @@ could stop a container from starting or that requires an invented value:
 | `Audit.PrivilegeEscalation` | set `allowPrivilegeEscalation: false` |
 
 Everything else stays **guidance-only** — `Audit.RunAsRoot` (enforcing non-root
-can break a root image), `Audit.HostNamespace`, `Audit.LatestTag` (never invent a
-tag), `Audit.MissingRequests` / `Audit.MissingLimits` (never invent CPU/memory),
-and any other workload kind (Pod, Job, CronJob templates are reported, not patched).
+can break a root image), `Audit.WritableRootFS` (enforcing a read-only root
+filesystem can break containers that write to disk), `Audit.HostNamespace`,
+`Audit.LatestTag` (never invent a tag), `Audit.MissingRequests` /
+`Audit.MissingLimits` (never invent CPU/memory), and any other workload kind
+(Pod, Job, CronJob templates are reported, not patched).
 
 ## Honest limits
 
-This MVP does **not** cover NetworkPolicy gaps, RBAC over-permission,
-PodSecurity admission levels, or `readOnlyRootFilesystem`. Findings are
-static template rules — not a CIS benchmark or live runtime attestation.
+This MVP does **not** cover NetworkPolicy gaps, RBAC over-permission, or
+PodSecurity admission levels. Findings are static template rules — not a
+CIS benchmark or live runtime attestation.

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -196,6 +196,13 @@ func scanContainer(out *incident.Investigation, w *workload, podSC *corev1.PodSe
 			w.kind, w.name, w.ns, "PrivilegeEscalation")
 	}
 
+	if csc == nil || csc.ReadOnlyRootFilesystem == nil || !*csc.ReadOnlyRootFilesystem {
+		addFinding(out, "Audit.WritableRootFS", incident.SeverityMedium,
+			fmt.Sprintf("%s/%s container %s has a writable root filesystem", w.kind, w.name, cname),
+			"securityContext.readOnlyRootFilesystem is not set to true",
+			w.kind, w.name, w.ns, "WritableRootFS")
+	}
+
 	if imageIsLatestOrUntagged(c.Image) {
 		addFinding(out, "Audit.LatestTag", incident.SeverityMedium,
 			fmt.Sprintf("%s/%s container %s uses a mutable image tag", w.kind, w.name, cname),

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -39,6 +39,7 @@ func TestAuditFindsHygieneIssues(t *testing.T) {
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot:             boolPtr(true),
 					AllowPrivilegeEscalation: boolPtr(false),
+					ReadOnlyRootFilesystem:   boolPtr(true),
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -69,8 +70,12 @@ func TestAuditFindsHygieneIssues(t *testing.T) {
 	requireFinding(t, got, "Audit.LatestTag", "Deployment/bad container app uses a mutable image tag")
 	requireFinding(t, got, "Audit.MissingLimits", "Deployment/bad container app is missing CPU/memory limits")
 	requireFinding(t, got, "Audit.RunAsRoot", "Deployment/bad container app may run as root")
+	requireFinding(t, got, "Audit.WritableRootFS", "Deployment/bad container app has a writable root filesystem")
 	if findingTitle(got, "Audit.Privileged", "Deployment/good") {
 		t.Fatal("clean deployment should not be privileged")
+	}
+	if findingTitle(got, "Audit.WritableRootFS", "Deployment/good") {
+		t.Fatal("clean deployment sets readOnlyRootFilesystem=true and should not be flagged")
 	}
 	if got.Confidence != 0.9 {
 		t.Fatalf("confidence=%v", got.Confidence)
@@ -88,6 +93,7 @@ func TestAuditCleanNamespace(t *testing.T) {
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot:             boolPtr(true),
 					AllowPrivilegeEscalation: boolPtr(false),
+					ReadOnlyRootFilesystem:   boolPtr(true),
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -113,6 +119,41 @@ func TestAuditCleanNamespace(t *testing.T) {
 	}
 	if !strings.Contains(got.Summary, "no issues matched MVP rules") {
 		t.Fatalf("summary=%q", got.Summary)
+	}
+}
+
+func TestAuditWritableRootFS(t *testing.T) {
+	cases := []struct {
+		name     string
+		roFS     *bool // nil = unset
+		wantFlag bool
+	}{
+		{"readonly-true", boolPtr(true), false},
+		{"readonly-false", boolPtr(false), true},
+		{"unset", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(
+				deployment(tc.name, "prod", corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx:1.27",
+						SecurityContext: &corev1.SecurityContext{
+							ReadOnlyRootFilesystem: tc.roFS,
+						},
+					}},
+				}),
+			)
+			got, err := (&Analyzer{Client: client}).Run(context.Background(), Request{Namespace: "prod"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			flagged := findingTitle(got, "Audit.WritableRootFS", "Deployment/"+tc.name)
+			if flagged != tc.wantFlag {
+				t.Fatalf("writable-root-fs flagged=%v want=%v; findings=%+v", flagged, tc.wantFlag, got.Findings)
+			}
+		})
 	}
 }
 

--- a/internal/suggest/audit.go
+++ b/internal/suggest/audit.go
@@ -253,6 +253,8 @@ func auditGuidanceTitle(code string) string {
 		return "Set resource limits"
 	case "Audit.MissingImagePullPolicy":
 		return "Set imagePullPolicy"
+	case "Audit.WritableRootFS":
+		return "Set a read-only root filesystem"
 	default:
 		return "Review finding"
 	}
@@ -280,6 +282,8 @@ func auditGuidanceSummary(code string) string {
 		return "Add resources.limits after profiling — CPU/memory values are workload-specific, not invented"
 	case "Audit.MissingImagePullPolicy":
 		return "Set imagePullPolicy (e.g. IfNotPresent) once the image tag is pinned"
+	case "Audit.WritableRootFS":
+		return "Set securityContext.readOnlyRootFilesystem=true and mount an emptyDir for paths that need writes — kprompt never auto-enables it because a container that writes to its root filesystem would break"
 	default:
 		return "Review the finding and remediate in your workload manifest"
 	}


### PR DESCRIPTION
## Why

`docs/audit.md` listed `readOnlyRootFilesystem` under "Honest limits" as out of scope, yet it's a clean, static, testable hardening check that improves audit coverage without inventing seccomp/PSA policy. This adds it as a guidance-only finding.

Fixes #74

## What changed

- **`internal/audit/audit.go`** — new `Audit.WritableRootFS` finding (severity Medium) in `scanContainer`, raised when a container's `securityContext.readOnlyRootFilesystem` is unset or `false`. Follows the existing securityContext check pattern (`RunAsRoot` / `Privileged` / `PrivilegeEscalation`).
- **`internal/suggest/audit.go`** — guidance-only title + summary for the new code. Intentionally **not** auto-patched: enforcing a read-only root filesystem can break containers that legitimately write to disk, so it stays guidance-only (same rationale as `Audit.RunAsRoot`).
- **`internal/audit/audit_test.go`** — new `TestAuditWritableRootFS` covering `true` / `false` / unset; existing clean fixtures updated to set `readOnlyRootFilesystem: true`.
- **`docs/audit.md`** — added to the MVP checks table + guidance-only list; removed from "Honest limits".

## Acceptance (#74)

- [x] New finding `Audit.WritableRootFS` when a container has `readOnlyRootFilesystem` unset or `false`
- [x] Unit tests covering true / false / unset
- [x] Updated `docs/audit.md` table + removed from honest-limits exclusion
- [x] Suggest path is guidance-only (no invented seccomp profiles)

## Testing

- `go test ./...` — all pass
- `gofmt` / `go vet` — clean
- `go build ./cmd/kprompt` — OK

## Note on severity

Set to **Medium**, consistent with the other securityContext container findings (e.g. `Audit.PrivilegeEscalation`). Happy to drop it to Low if you'd rather it not compete with higher-signal findings.

---
<sub>Disclosure: this change was prepared with AI assistance (Claude Code); I reviewed the diff and verified the test suite, gofmt, and vet locally.</sub>
