### PR TITLE
feat(timeline): add StatefulSet and DaemonSet chronology

### DIFF
--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -1,6 +1,6 @@
 # timeline (S-004)
 
-Ordered **incident chronology** for a workload — Events + ReplicaSet/rollout revisions + HPA — not chat scroll.
+Ordered **incident chronology** for a workload — Events + rollout/controller revisions + HPA where applicable — not chat scroll.
 
 Emits the same ADR-0014 **`Investigation`** artifact; the primary payload is `timeline[]` of `EvidenceRef` (time-sorted).
 
@@ -9,6 +9,8 @@ Emits the same ADR-0014 **`Investigation`** artifact; the primary payload is `ti
 ```bash
 kprompt "timeline for api" -n payments
 kprompt "what happened to ledger" -n payments -o json
+kprompt "timeline for StatefulSet db" -n payments
+kprompt "what happened to DaemonSet node-agent" -n kube-system
 ```
 
 Optional window (default `1h`):
@@ -20,13 +22,14 @@ kprompt "timeline for api" -n payments
 
 ## Sources (MVP)
 
-1. **Events** on the Deployment (or Pod) and owned pods
-2. **ReplicaSet** revisions (`deployment.kubernetes.io/revision`)
-3. **HPA** targeting the Deployment (status + condition transitions)
+1. **Events** on the target workload (Deployment, StatefulSet, DaemonSet, or Pod) and related pods
+2. **ReplicaSet** revisions for Deployments (`deployment.kubernetes.io/revision`)
+3. **ControllerRevision** history for StatefulSets and DaemonSets where available
+4. **HPA** targeting the Deployment (status + condition transitions)
 
 ## Honest gaps (`degraded`)
 
-MVP lists `prometheus`, `otel`, and `mesh` in `Investigation.degraded` — metrics/traces/mesh hops are not walked yet.
+MVP lists `prometheus`, `otel`, and `mesh` in `Investigation.degraded` — metrics/traces/mesh hops are not walked yet, and timeline does not invent those signals for StatefulSets or DaemonSets.
 
 ## vs `investigate` / `why`
 

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -31,7 +31,7 @@ const (
 type Request struct {
 	Name      string
 	Namespace string
-	Kind      string // Pod or Deployment
+	Kind      string // Pod, Deployment, StatefulSet, or DaemonSet
 	Prompt    string
 	Window    time.Duration // lookback; default 1h
 }
@@ -54,8 +54,8 @@ func (b *Builder) Run(ctx context.Context, req Request) (incident.Investigation,
 	if name == "" {
 		return incident.Investigation{}, fmt.Errorf("timeline: target name required")
 	}
-	kind := cluster.NormalizeKind(req.Kind)
-	if kind != "Pod" && kind != "Deployment" {
+	kind := normalizeTimelineKind(req.Kind)
+	if kind != "Pod" && kind != "Deployment" && kind != "StatefulSet" && kind != "DaemonSet" {
 		kind = "Deployment"
 	}
 	window := req.Window
@@ -84,13 +84,12 @@ func (b *Builder) Run(ctx context.Context, req Request) (incident.Investigation,
 			findings = append(findings, finding("Timeline.Events", incident.SeverityInfo,
 				"Pod events", fmt.Sprintf("%d Event(s) for Pod/%s in last %s", n, name, window)))
 		}
-	default:
+	case "Deployment":
 		dep, err := b.Client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return incident.Investigation{}, err
 		}
 		entries = append(entries, objectStamp("Deployment", dep.Name, ns, dep.CreationTimestamp.Time, "created")...)
-
 		rsEntries, rsFinding := b.replicaSetEntries(ctx, ns, dep, cutoff)
 		entries = append(entries, rsEntries...)
 		if rsFinding != nil {
@@ -112,6 +111,52 @@ func (b *Builder) Run(ctx context.Context, req Request) (incident.Investigation,
 		if hpaFinding != nil {
 			findings = append(findings, *hpaFinding)
 		}
+	case "StatefulSet":
+		sts, err := b.Client.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return incident.Investigation{}, err
+		}
+		entries = append(entries, objectStamp("StatefulSet", sts.Name, ns, sts.CreationTimestamp.Time, "created")...)
+
+		revEntries, revFinding := b.controllerRevisionEntries(ctx, ns, "StatefulSet", sts.Name, string(sts.UID), cutoff)
+		entries = append(entries, revEntries...)
+		if revFinding != nil {
+			findings = append(findings, *revFinding)
+		}
+
+		evs, n := b.eventsFor(ctx, ns, "StatefulSet", name, cutoff)
+		entries = append(entries, evs...)
+		podEvs, pn := b.podEventsForSelector(ctx, ns, sts.Spec.Selector, cutoff)
+		entries = append(entries, podEvs...)
+		totalEv := n + pn
+		if totalEv > 0 {
+			findings = append(findings, finding("Timeline.Events", incident.SeverityInfo,
+				"Workload events", fmt.Sprintf("%d Event(s) for StatefulSet/%s (incl. pods) in last %s", totalEv, name, window)))
+		}
+	case "DaemonSet":
+		ds, err := b.Client.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return incident.Investigation{}, err
+		}
+		entries = append(entries, objectStamp("DaemonSet", ds.Name, ns, ds.CreationTimestamp.Time, "created")...)
+
+		revEntries, revFinding := b.controllerRevisionEntries(ctx, ns, "DaemonSet", ds.Name, string(ds.UID), cutoff)
+		entries = append(entries, revEntries...)
+		if revFinding != nil {
+			findings = append(findings, *revFinding)
+		}
+
+		evs, n := b.eventsFor(ctx, ns, "DaemonSet", name, cutoff)
+		entries = append(entries, evs...)
+		podEvs, pn := b.podEventsForSelector(ctx, ns, ds.Spec.Selector, cutoff)
+		entries = append(entries, podEvs...)
+		totalEv := n + pn
+		if totalEv > 0 {
+			findings = append(findings, finding("Timeline.Events", incident.SeverityInfo,
+				"Workload events", fmt.Sprintf("%d Event(s) for DaemonSet/%s (incl. pods) in last %s", totalEv, name, window)))
+		}
+	default:
+		return incident.Investigation{}, fmt.Errorf("timeline: unsupported kind %q", req.Kind)
 	}
 
 	entries = dedupeSortTruncate(entries, cutoff, maxEntries)
@@ -134,8 +179,8 @@ func (b *Builder) Run(ctx context.Context, req Request) (incident.Investigation,
 
 func (b *Builder) replicaSetEntries(ctx context.Context, ns string, dep *appsv1.Deployment, cutoff time.Time) ([]incident.EvidenceRef, *incident.Finding) {
 	sel := labels.Everything().String()
-	if dep.Spec.Selector != nil && len(dep.Spec.Selector.MatchLabels) > 0 {
-		sel = labels.Set(dep.Spec.Selector.MatchLabels).String()
+	if x, ok := selectorString(dep.Spec.Selector); ok {
+		sel = x
 	}
 	list, err := b.Client.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{LabelSelector: sel})
 	if err != nil {
@@ -234,12 +279,15 @@ func (b *Builder) hpaEntries(ctx context.Context, ns, deployName string, cutoff 
 }
 
 func (b *Builder) podEvents(ctx context.Context, ns string, dep *appsv1.Deployment, cutoff time.Time) ([]incident.EvidenceRef, int) {
-	if dep.Spec.Selector == nil || len(dep.Spec.Selector.MatchLabels) == 0 {
+	return b.podEventsForSelector(ctx, ns, dep.Spec.Selector, cutoff)
+}
+
+func (b *Builder) podEventsForSelector(ctx context.Context, ns string, sel *metav1.LabelSelector, cutoff time.Time) ([]incident.EvidenceRef, int) {
+	labelSelector, ok := selectorString(sel)
+	if !ok {
 		return nil, 0
 	}
-	pods, err := b.Client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set(dep.Spec.Selector.MatchLabels).String(),
-	})
+	pods, err := b.Client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, 0
 	}
@@ -258,6 +306,49 @@ func (b *Builder) podEvents(ctx context.Context, ns string, dep *appsv1.Deployme
 	return out, total
 }
 
+func (b *Builder) controllerRevisionEntries(ctx context.Context, ns, ownerKind, ownerName, ownerUID string, cutoff time.Time) ([]incident.EvidenceRef, *incident.Finding) {
+	list, err := b.Client.AppsV1().ControllerRevisions(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		f := finding("Timeline.ControllerRevisionError", incident.SeverityLow, "ControllerRevision list failed", err.Error())
+		return nil, &f
+	}
+	var out []incident.EvidenceRef
+	count := 0
+	for i := range list.Items {
+		rev := &list.Items[i]
+		if !ownedByControllerRevision(rev, ownerKind, ownerUID) {
+			continue
+		}
+		ts := rev.CreationTimestamp.Time
+		if ts.Before(cutoff) {
+			continue
+		}
+		if rev.Revision == 0 {
+			continue
+		}
+		msg := fmt.Sprintf("ControllerRevision/%s revision=%d for %s/%s", rev.Name, rev.Revision, ownerKind, ownerName)
+		out = append(out, incident.EvidenceRef{
+			Type:      incident.EvidenceObject,
+			Resource:  &incident.ResourceRef{Kind: "ControllerRevision", Name: rev.Name, Namespace: ns},
+			Reason:    "Rollout",
+			Message:   msg,
+			Timestamp: timePtr(ts),
+			Source:    "kubernetes",
+		})
+		evs, _ := b.eventsFor(ctx, ns, "ControllerRevision", rev.Name, cutoff)
+		out = append(out, evs...)
+		count++
+	}
+	if count == 0 {
+		return out, nil
+	}
+	f := finding("Timeline.ControllerRevisions", incident.SeverityInfo,
+		"Controller revisions", fmt.Sprintf("%d ControllerRevision(s) for %s/%s", count, ownerKind, ownerName))
+	return out, &f
+}
 func (b *Builder) eventsFor(ctx context.Context, ns, kind, name string, cutoff time.Time) ([]incident.EvidenceRef, int) {
 	list, err := b.Client.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s", kind, name),
@@ -300,6 +391,20 @@ func objectStamp(kind, name, ns string, created time.Time, reason string) []inci
 	}}
 }
 
+func normalizeTimelineKind(k string) string {
+	switch strings.ToLower(strings.TrimSpace(cluster.NormalizeKind(k))) {
+	case "", "deployment":
+		return "Deployment"
+	case "pod":
+		return "Pod"
+	case "statefulset", "statefulsets", "sts":
+		return "StatefulSet"
+	case "daemonset", "daemonsets", "ds":
+		return "DaemonSet"
+	default:
+		return strings.TrimSpace(cluster.NormalizeKind(k))
+	}
+}
 func ownedBy(rs *appsv1.ReplicaSet, dep *appsv1.Deployment) bool {
 	for _, o := range rs.OwnerReferences {
 		if o.UID == dep.UID && o.Kind == "Deployment" {
@@ -307,6 +412,26 @@ func ownedBy(rs *appsv1.ReplicaSet, dep *appsv1.Deployment) bool {
 		}
 	}
 	return false
+}
+
+func ownedByControllerRevision(rev *appsv1.ControllerRevision, ownerKind, ownerUID string) bool {
+	for _, o := range rev.OwnerReferences {
+		if o.Kind == ownerKind && string(o.UID) == ownerUID {
+			return true
+		}
+	}
+	return false
+}
+
+func selectorString(sel *metav1.LabelSelector) (string, bool) {
+	if sel == nil {
+		return "", false
+	}
+	x, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil || x.Empty() {
+		return "", false
+	}
+	return x.String(), true
 }
 
 func eventTime(ev *corev1.Event) time.Time {

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -2,6 +2,7 @@ package timeline
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -144,9 +145,171 @@ func TestBuilderPodTimeline(t *testing.T) {
 	}
 }
 
+func TestBuilderStatefulSetTimeline(t *testing.T) {
+	ns := "payments"
+	now := time.Now().UTC()
+	client := fake.NewSimpleClientset(
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "db", Namespace: ns, UID: types.UID("sts1"),
+				CreationTimestamp: metav1.NewTime(now.Add(-90 * time.Minute)),
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "db"}},
+			},
+		},
+		&appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "db-rev-1", Namespace: ns,
+				CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Minute)),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "apps/v1", Kind: "StatefulSet", Name: "db", UID: "sts1",
+				}},
+			},
+			Revision: 3,
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "db-0", Namespace: ns, Labels: map[string]string{"app": "db"},
+			},
+		},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "sts-ev", Namespace: ns},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "StatefulSet", Name: "db", Namespace: ns,
+			},
+			Reason:        "SuccessfulCreate",
+			Message:       "create Pod db-0 in StatefulSet db successful",
+			LastTimestamp: metav1.NewTime(now.Add(-20 * time.Minute)),
+		},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-ev", Namespace: ns},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod", Name: "db-0", Namespace: ns,
+			},
+			Reason:        "Pulled",
+			Message:       "Container image pulled",
+			LastTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+		},
+	)
+
+	doc, err := (&Builder{Client: client}).Run(context.Background(), Request{
+		Name: "db", Namespace: ns, Kind: "statefulset",
+		Prompt: "timeline for statefulset db", Window: 2 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.Target == nil || doc.Target.Kind != "StatefulSet" {
+		t.Fatalf("expected StatefulSet target, got %+v", doc.Target)
+	}
+	if !hasCode(doc.Findings, "Timeline.ControllerRevisions") {
+		t.Fatalf("missing controller revision finding: %+v", doc.Findings)
+	}
+	if !hasCode(doc.Findings, "Timeline.Events") {
+		t.Fatalf("missing events finding: %+v", doc.Findings)
+	}
+	if !timelineContainsMessage(doc.Timeline, "ControllerRevision/db-rev-1 revision=3") {
+		t.Fatalf("missing controller revision entry: %+v", doc.Timeline)
+	}
+	if !timelineContainsResource(doc.Timeline, "Pod", "db-0") {
+		t.Fatalf("missing related pod evidence: %+v", doc.Timeline)
+	}
+}
+
+func TestBuilderDaemonSetTimeline(t *testing.T) {
+	ns := "payments"
+	now := time.Now().UTC()
+	client := fake.NewSimpleClientset(
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-agent", Namespace: ns, UID: types.UID("ds1"),
+				CreationTimestamp: metav1.NewTime(now.Add(-70 * time.Minute)),
+			},
+			Spec: appsv1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-agent"}},
+			},
+		},
+		&appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-agent-rev-1", Namespace: ns,
+				CreationTimestamp: metav1.NewTime(now.Add(-40 * time.Minute)),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "apps/v1", Kind: "DaemonSet", Name: "node-agent", UID: "ds1",
+				}},
+			},
+			Revision: 7,
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-agent-abc", Namespace: ns, Labels: map[string]string{"app": "node-agent"},
+			},
+		},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "ds-ev", Namespace: ns},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "DaemonSet", Name: "node-agent", Namespace: ns,
+			},
+			Reason:        "RollingUpdate",
+			Message:       "updated DaemonSet pods",
+			LastTimestamp: metav1.NewTime(now.Add(-25 * time.Minute)),
+		},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "ds-pod-ev", Namespace: ns},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod", Name: "node-agent-abc", Namespace: ns,
+			},
+			Reason:        "Started",
+			Message:       "Started container agent",
+			LastTimestamp: metav1.NewTime(now.Add(-15 * time.Minute)),
+		},
+	)
+
+	doc, err := (&Builder{Client: client}).Run(context.Background(), Request{
+		Name: "node-agent", Namespace: ns, Kind: "ds",
+		Prompt: "what happened to daemonset node-agent", Window: 2 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.Target == nil || doc.Target.Kind != "DaemonSet" {
+		t.Fatalf("expected DaemonSet target, got %+v", doc.Target)
+	}
+	if !hasCode(doc.Findings, "Timeline.ControllerRevisions") {
+		t.Fatalf("missing controller revision finding: %+v", doc.Findings)
+	}
+	if !hasCode(doc.Findings, "Timeline.Events") {
+		t.Fatalf("missing events finding: %+v", doc.Findings)
+	}
+	if !timelineContainsMessage(doc.Timeline, "ControllerRevision/node-agent-rev-1 revision=7") {
+		t.Fatalf("missing daemonset controller revision entry: %+v", doc.Timeline)
+	}
+	if !timelineContainsResource(doc.Timeline, "Pod", "node-agent-abc") {
+		t.Fatalf("missing daemonset pod evidence: %+v", doc.Timeline)
+	}
+}
+
 func hasCode(fs []incident.Finding, code string) bool {
 	for _, f := range fs {
 		if f.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func timelineContainsMessage(entries []incident.EvidenceRef, want string) bool {
+	for _, e := range entries {
+		if strings.Contains(e.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func timelineContainsResource(entries []incident.EvidenceRef, kind, name string) bool {
+	for _, e := range entries {
+		if e.Resource != nil && e.Resource.Kind == kind && e.Resource.Name == name {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
Closes #82

Adds StatefulSet and DaemonSet support to timeline chronology, including workload events, related pod events, and ControllerRevision entries where available.

## Changes
- add StatefulSet timeline support
- add DaemonSet timeline support
- collect related pod events via workload selectors
- collect ControllerRevision history where available
- keep prometheus / otel / mesh as degraded-only signals (out of scope for this change)
- update docs/timeline.md
- add fake-client unit tests for StatefulSet and DaemonSet chronology

## Test plan
- `go test ./internal/timeline`
- `go test ./...`

## Notes
- ControllerRevision entries fetch per-revision Events to preserve chronology detail. This introduces extra API calls with many revisions; the default 1h lookback window limits overhead under typical usage.
- HPA chronology remains Deployment-only in this PR. Extending HPA support for StatefulSets will be handled in separate work.