### PR TITLE
feat: add shell completions for bash/zsh/fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ go build -o bin/kprompt ./cmd/kprompt
 ./bin/kprompt version
 ```
 
+### Shell autocompletion
+
+To enable autocompletions for your shell:
+
+```bash
+# Bash
+source <(kprompt completion bash)
+
+# Zsh
+source <(kprompt completion zsh)
+
+# Fish
+kprompt completion fish > ~/.config/fish/completions/kprompt.fish
+```
+
+See `kprompt completion --help` for details on how to persist completions.
+
 ## Transparent metrics
 
 The Free CLI does **not** phone home. Adoption signals stay public and passive:

--- a/cmd/kprompt/completion.go
+++ b/cmd/kprompt/completion.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "completion [bash|zsh|fish]",
+		Short: "Generate shell completion scripts",
+		Long: `To load completions:
+
+Bash:
+
+  $ source <(kprompt completion bash)
+
+  # To load completions for each session, add this to your ~/.bashrc:
+  $ source <(kprompt completion bash)
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, add this to your ~/.zshrc:
+  $ source <(kprompt completion zsh)
+
+Fish:
+
+  $ kprompt completion fish > ~/.config/fish/completions/kprompt.fish
+`,
+		Hidden:                true,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletionV2(cmd.OutOrStdout(), true)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(cmd.OutOrStdout())
+			case "fish":
+				return cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
+			default:
+				return fmt.Errorf("unsupported shell %s", args[0])
+			}
+		},
+	}
+}

--- a/cmd/kprompt/completion_test.go
+++ b/cmd/kprompt/completion_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCompletionCmd(t *testing.T) {
+	tests := []struct {
+		shell string
+	}{
+		{"bash"},
+		{"zsh"},
+		{"fish"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			root := &cobra.Command{Use: "kprompt"}
+			root.AddCommand(newCompletionCmd())
+
+			buf := new(bytes.Buffer)
+			root.SetOut(buf)
+			root.SetErr(buf)
+			root.SetArgs([]string{"completion", tt.shell})
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			output := buf.String()
+			if len(output) == 0 {
+				t.Fatalf("empty output generated for %s", tt.shell)
+			}
+
+			// basic sanity checks
+			if tt.shell == "bash" && !strings.Contains(output, "complete -o") {
+				t.Fatalf("expected bash completion function in output")
+			}
+			if tt.shell == "zsh" && !strings.Contains(output, "#compdef") {
+				t.Fatalf("expected zsh completion function in output")
+			}
+			if tt.shell == "fish" && !strings.Contains(output, "complete -c") {
+				t.Fatalf("expected fish completion function in output")
+			}
+		})
+	}
+}
+
+func TestCompletionCmdInvalid(t *testing.T) {
+	root := &cobra.Command{Use: "kprompt"}
+	root.AddCommand(newCompletionCmd())
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs([]string{"completion", "invalid-shell"})
+
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for invalid shell")
+	}
+}

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -121,6 +121,7 @@ func main() {
 			fmt.Fprintln(cmd.OutOrStdout(), version)
 		},
 	})
+	root.AddCommand(newCompletionCmd())
 	root.AddCommand(newConfigCmd())
 	root.AddCommand(newThemeCmd())
 	root.AddCommand(newContextsCmd())

--- a/cmd/kprompt/recipe.go
+++ b/cmd/kprompt/recipe.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -68,9 +69,10 @@ func newRecipeListCmd() *cobra.Command {
 
 func newRecipeShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <id>",
-		Short: "Show one recipe (steps + notes)",
-		Args:  cobra.ExactArgs(1),
+		Use:               "show <id>",
+		Short:             "Show one recipe (steps + notes)",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completeRecipeIDs,
 		Example: `  # Show details of the harden-production recipe
   kprompt recipe show harden-production`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -92,15 +94,16 @@ func newRecipeRunCmd() *cobra.Command {
 	var outputFmt string
 
 	cmd := &cobra.Command{
-		Use:   "run <id>",
-		Short: "Expand and execute a recipe as a multi-step route",
-		Args:  cobra.ExactArgs(1),
+		Use:               "run <id>",
+		Short:             "Expand and execute a recipe as a multi-step route",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completeRecipeIDs,
 		Example: `  # Run a recipe in a specific namespace
   kprompt recipe run harden-production -n payments
-
+ 
   # Run a recipe with workload and namespace overrides
   kprompt recipe run crashloop-rca --workload api -n payments
-
+ 
   # Run a recipe and automatically approve mutating steps
   kprompt recipe run oom-rca --workload backend --approve`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -141,4 +144,17 @@ func newRecipeRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&approve, "approve", false, "approve mutating steps in the recipe route")
 	cmd.Flags().StringVarP(&outputFmt, "output", "o", "text", "output format: text|json")
 	return cmd
+}
+
+func completeRecipeIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var completions []string
+	for _, r := range recipe.Catalog() {
+		if strings.HasPrefix(strings.ToLower(r.ID), strings.ToLower(toComplete)) {
+			completions = append(completions, fmt.Sprintf("%s\t%s", r.ID, r.Summary))
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/kprompt/recipe_test.go
+++ b/cmd/kprompt/recipe_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRecipeShowCompletion(t *testing.T) {
+	cmd := newRecipeShowCmd()
+	if cmd.ValidArgsFunction == nil {
+		t.Fatal("expected ValidArgsFunction to be set")
+	}
+	// Call ValidArgsFunction
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	if len(completions) == 0 {
+		t.Fatal("expected recipe IDs in completion list")
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected directive ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+
+	// Try with a prefix
+	completions, _ = cmd.ValidArgsFunction(cmd, []string{}, "har")
+	for _, c := range completions {
+		if !strings.HasPrefix(strings.ToLower(c), "har") {
+			t.Fatalf("unexpected completion value for prefix 'har': %s", c)
+		}
+	}
+
+	// Try when arg already exists
+	completions, _ = cmd.ValidArgsFunction(cmd, []string{"harden-production"}, "")
+	if len(completions) != 0 {
+		t.Fatalf("expected no completions if argument is already provided, got %v", completions)
+	}
+}
+
+func TestRecipeRunCompletion(t *testing.T) {
+	cmd := newRecipeRunCmd()
+	if cmd.ValidArgsFunction == nil {
+		t.Fatal("expected ValidArgsFunction to be set")
+	}
+	// Call ValidArgsFunction
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	if len(completions) == 0 {
+		t.Fatal("expected recipe IDs in completion list")
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected directive ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+}


### PR DESCRIPTION
### Summary

Adds shell autocompletions for `bash`, `zsh` and `fish` to `kprompt` using Cobra's native completion capabilities. Additionally, it wires context-aware autocompletions for curated recipe IDs when typing `kprompt recipe show` or `kprompt recipe run`. 

Fixes #73

### Changes

- `cmd/kprompt/completion.go`: Added `completion` command to print shell completion scripts for `bash`, `zsh` and `fish`.
- `cmd/kprompt/main.go`: Registered the `completion` command.
- `cmd/kprompt/recipe.go`: Added `ValidArgsFunction` to retrieve and match built-in recipe IDs from `recipe.Catalog()`.
- `cmd/kprompt/completion_test.go`: Added unit tests verifying script output for each supported shell.
- `cmd/kprompt/recipe_test.go`: Added unit tests verifying autocompletion filtering and behavior of recipe subcommands.
- `README.md`: Documented how to load completions.

### Test plan

- [x] `go build -o bin/kprompt ./cmd/kprompt` compiles successfully.
- [x] `go test ./cmd/kprompt/...` passes successfully.
- [x] Manual: verified completion outputs render properly for `bash`, `zsh`.

### Screenshots

<img width="1026" height="648" alt="image" src="https://github.com/user-attachments/assets/745b08df-039b-413f-ba79-6a2e1b80af6b" />

zsh
<img width="914" height="60" alt="image" src="https://github.com/user-attachments/assets/98ba1131-3f26-4bc8-b423-2ab7a462c4cd" />

<img width="938" height="46" alt="image" src="https://github.com/user-attachments/assets/9c3ffce4-6c4c-4e9e-a930-4ff81dd68f93" />

Bash
<img width="752" height="66" alt="image" src="https://github.com/user-attachments/assets/b40b2a78-3aa9-42ff-b953-536bf29ea187" />

fish
<img width="1043" height="126" alt="image" src="https://github.com/user-attachments/assets/3f7e2bd3-5982-4176-9242-3daddc8a419e" />

### Usage of AI

Use: Yes
Model: Gemini 1.5 Pro
Used for: Implementing the Cobra shell completion subcommands, writing unit tests, and drafting installation docs.
