### PR TITLE
feat(agent): add Discord notify adapter

### DIFF
--- a/cmd/kprompt/agent.go
+++ b/cmd/kprompt/agent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kprompt/kprompt/internal/agent/health"
 	agentlogs "github.com/kprompt/kprompt/internal/agent/logs"
 	"github.com/kprompt/kprompt/internal/agent/memory"
+	agentdiscord "github.com/kprompt/kprompt/internal/agent/notify/discord"
 	agentslack "github.com/kprompt/kprompt/internal/agent/notify/slack"
 	"github.com/kprompt/kprompt/internal/agent/notify/slack/ask"
 	agentwebhook "github.com/kprompt/kprompt/internal/agent/notify/webhook"
@@ -613,6 +614,8 @@ func newAgentRunCmd() *cobra.Command {
 		buildContext     bool
 		doAnalyze        bool
 		heuristic        bool
+		notifyDiscord    bool
+		discordURL       string
 		notifySlack      bool
 		notifyWebhook    bool
 		webhookURL       string
@@ -657,6 +660,7 @@ Pipeline flags (read-only — never mutate workload objects):
   --fetch-logs     on-demand log tail on CrashLoop/Failed/OOM
   --build-context  assemble AgentContext
   --analyze        LLM/heuristic → gated AgentAlert
+  --discord       post gated alerts to Discord webhook
   --slack          post gated alerts to Slack threads
   --webhook        POST gated AgentAlert JSON to a URL
   --health         emit namespace health score / risk_increasing
@@ -692,6 +696,9 @@ Slack credentials from env / mounted Secret:
 Generic webhook:
   KPROMPT_WEBHOOK_URL  or  --webhook-url
 
+Discord:
+  KPROMPT_DISCORD_WEBHOOK_URL  or  --discord-webhook-url
+
 KpromptAgent status sync:
   --agent-cr / KPROMPT_AGENT_CR  (+ optional --agent-cr-namespace)`,
 		Example: `  kprompt agent run -n payments --health --heuristic
@@ -708,7 +715,7 @@ KpromptAgent status sync:
 				trackHealth = true
 				doAnalyze = true
 			}
-			if notifySlack || notifyWebhook {
+			if notifyDiscord || notifySlack || notifyWebhook {
 				doAnalyze = true
 			}
 			if trackHealth && !incidents {
@@ -751,6 +758,7 @@ KpromptAgent status sync:
 			var fetcher *agentlogs.Fetcher
 			var ctxBuilder *ctxbuild.Builder
 			var analyzer *analyze.Analyzer
+			var discordClient *agentdiscord.Client
 			var slackClient *agentslack.Client
 			var webhookClient *agentwebhook.Client
 			var healthTracker *health.Tracker
@@ -888,6 +896,16 @@ KpromptAgent status sync:
 					analyzer.Patterns = patterns.New(pstore)
 				}
 			}
+			if notifyDiscord {
+				dcfg := agentdiscord.ConfigFromEnv()
+				if u := strings.TrimSpace(discordURL); u != "" {
+					dcfg.URL = u
+				}
+				if !dcfg.Enabled() {
+					return fmt.Errorf("--discord requires %s or --discord-webhook-url", agentdiscord.EnvWebhookURL)
+				}
+				discordClient = agentdiscord.New(dcfg)
+			}
 			if notifySlack {
 				scfg := agentslack.ConfigFromEnv()
 				if !scfg.Enabled() {
@@ -976,6 +994,11 @@ KpromptAgent status sync:
 						if webhookClient != nil && outcome.PassedGate {
 							if err := webhookClient.Notify(cmd.Context(), outcome.Alert); err != nil {
 								fmt.Fprintf(cmd.ErrOrStderr(), "webhook notify error: %v\n", err)
+							}
+						}
+						if discordClient != nil && outcome.PassedGate {
+							if err := discordClient.Notify(cmd.Context(), outcome.Alert); err != nil {
+								fmt.Fprintf(cmd.ErrOrStderr(), "discord notify error: %v\n", err)
 							}
 						}
 						if statusSync != nil && outcome.PassedGate {
@@ -1168,7 +1191,7 @@ KpromptAgent status sync:
 
 			mode := "Pods+Events"
 			switch {
-			case notifySlack || notifyWebhook:
+			case notifyDiscord || notifySlack || notifyWebhook:
 				mode = "watch → analyze → notify"
 			case doAnalyze:
 				mode = "watch → incidents → context → analyze"
@@ -1259,6 +1282,8 @@ KpromptAgent status sync:
 	cmd.Flags().BoolVar(&fetchLogs, "fetch-logs", false, "on CrashLoop/Failed/OOM attach a short log tail (enables --incidents)")
 	cmd.Flags().BoolVar(&buildContext, "build-context", false, "assemble AgentContext for LLM (enables --incidents)")
 	cmd.Flags().BoolVar(&doAnalyze, "analyze", false, "run LLM/heuristic analyzer → gated AgentAlert")
+	cmd.Flags().BoolVar(&notifyDiscord, "discord", false, "post gated alerts to Discord webhook (enables --analyze)")
+	cmd.Flags().StringVar(&discordURL, "discord-webhook-url", "", "override KPROMPT_DISCORD_WEBHOOK_URL for --discord")
 	cmd.Flags().BoolVar(&notifySlack, "slack", false, "post gated alerts to Slack (enables --analyze)")
 	cmd.Flags().BoolVar(&notifyWebhook, "webhook", false, "POST gated AgentAlert JSON to webhook URL (enables --analyze)")
 	cmd.Flags().StringVar(&webhookURL, "webhook-url", "", "override KPROMPT_WEBHOOK_URL for --webhook")

--- a/docs/agent-ops.md
+++ b/docs/agent-ops.md
@@ -7,7 +7,7 @@ Companion: [agent.md](./agent.md) · [namespace-agent.md](./namespace-agent.md) 
 ## Install checklist
 
 1. Pick **one watch namespace** (or one agent Deployment per ns).
-2. Create Secret for LLM + Slack/webhook (never put keys in values/CRD plaintext).
+2. Create Secret for LLM + Discord/Slack/webhook (never put keys in values/CRD plaintext).
 3. `helm upgrade --install` with image your cluster can pull.
 4. Confirm Role is namespaced: `kubectl -n <ns> get role,rolebinding,sa -l app.kubernetes.io/name=kprompt-agent`.
 5. Tail agent logs; expect `watching namespace … (read-only)`.
@@ -42,6 +42,7 @@ Argo CD Applications often live in `argocd`, not the app ns — `--gitops-eviden
 | `--min-severity` / `--min-confidence` | Defaults medium / 0.7 — raise to cut noise |
 | Incident batching | One LLM call per evidence fingerprint, not per raw Event |
 | `--patterns` | Local disk/CM; no cloud upload; dampens repeat analysis quality issues |
+| Discord webhook | Simple gated alert posts; keep webhook URL in Secret |
 | Slack threads | Prefer bot token + channel over webhook for update-in-thread |
 | Prom / OTel | Optional; missing → `degraded:` — no invented metrics |
 
@@ -63,6 +64,7 @@ All of the above stay **local / in-cluster** — not uploaded to `api.kprompt.ai
 | Symptom | Check |
 |---------|--------|
 | No alerts | Gate (`min-severity` / `min-confidence`); is `--analyze` on? Open incidents? |
+| Discord silent | `--discord` plus `KPROMPT_DISCORD_WEBHOOK_URL` or `--discord-webhook-url`; check webhook permissions |
 | `degraded: prometheus\|otel\|gitops` | Backend URL / CRDs / RBAC; expected when opt-in signal missing |
 | Slack ask silent | `--slack-ask` + bot token; Events API URL / port-forward to `--slack-ask-addr` |
 | False-positive learning no-op | Need `--patterns` with ask callback |
@@ -72,7 +74,7 @@ All of the above stay **local / in-cluster** — not uploaded to `api.kprompt.ai
 
 ## Security hygiene
 
-- Rotate provider + Slack tokens via Secret; restart Deployment.
+- Rotate provider + Discord/Slack webhook URLs and tokens via Secret; restart Deployment.
 - Never enable Secret **value** reads (agent does not support it).
 - Treat InvestigationReport / Slack text as sensitive (may include log snippets).
 - Autopilot propose audit files may name workloads — protect laptop paths in shared demos.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,6 +1,6 @@
 # kprompt Observe agent
 
-In-cluster, **namespace-scoped** agent that continuously watches Pods/Events (and optional workloads), correlates incidents, optionally analyzes with an LLM, and notifies Slack/webhooks.
+In-cluster, **namespace-scoped** agent that continuously watches Pods/Events (and optional workloads), correlates incidents, optionally analyzes with an LLM, and notifies Discord, Slack, or webhooks.
 
 This is **Observe Mode** by default — it never applies, patches, or deletes cluster resources ([ADR-0013](https://github.com/kprompt/kprompt-architecture/blob/main/decisions/ADR-0013-in-cluster-agent.md)). Optional `--autopilot-propose` emits PlanResult-shaped proposals only ([ADR-0015](https://github.com/kprompt/kprompt-architecture/blob/main/decisions/ADR-0015-autopilot-mode.md)); **apply** stays gated. The Namespace Agent continuous-intelligence contract is [ADR-0016](https://github.com/kprompt/kprompt-architecture/blob/main/decisions/ADR-0016-namespace-agent.md).
 
@@ -42,7 +42,7 @@ Default install is a **Role + RoleBinding in one namespace** (get/list/watch on 
 
 ## LLM cost
 
-- The agent does **not** call the LLM on every raw API event. It batches by open **Incident**, then applies a **severity + confidence gate** before Slack/webhook.
+- The agent does **not** call the LLM on every raw API event. It batches by open **Incident**, then applies a **severity + confidence gate** before Discord/Slack/webhook.
 - Prefer `--heuristic` for demos / offline; turn LLM on when you accept API spend.
 - Gate tighter with `--min-severity` / `--min-confidence` (defaults: medium / 0.7) to limit alert fatigue and token burn.
 - Credentials stay in a **Secret** (`envFrom`) — never in CRD/ConfigMap plaintext.
@@ -52,6 +52,7 @@ Default install is a **Role + RoleBinding in one namespace** (get/list/watch on 
 ```bash
 kprompt agent run -n payments --analyze --fetch-logs --health --heuristic
 kprompt agent run -n payments --slack --fetch-logs   # needs Slack env
+kprompt agent run -n payments --discord --fetch-logs # needs Discord webhook env
 ```
 
 Need a namespace that actually misbehaves? [kprompt-examples](https://github.com/kprompt/kprompt-examples) provisions a kind cluster plus seven failure scenarios (crashloop, image pull, OOM, stalled rollout, unbound PVC, failing CronJob, missing dependency), each documenting what the agent is expected to conclude:
@@ -157,6 +158,7 @@ Chart: [`charts/kprompt-operator`](../charts/kprompt-operator).
 | Env key | Purpose |
 |---------|---------|
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / … | LLM (same as CLI) |
+| `KPROMPT_DISCORD_WEBHOOK_URL` | Discord webhook URL for gated AgentAlert text |
 | `KPROMPT_SLACK_BOT_TOKEN` + `KPROMPT_SLACK_CHANNEL` | Threaded Slack (preferred) |
 | `KPROMPT_SLACK_WEBHOOK_URL` | Slack webhook fallback |
 | `KPROMPT_WEBHOOK_URL` | Generic AgentAlert JSON POST |
@@ -216,6 +218,8 @@ Secrets are never watched implicitly and only metadata (type + key count) is emi
 | `--fetch-logs` | AG-005 on-demand logs |
 | `--build-context` | AG-007 context |
 | `--analyze` | AG-008 gated AgentAlert |
+| `--discord` | Discord webhook gated alerts |
+| `--discord-webhook-url` | Override `KPROMPT_DISCORD_WEBHOOK_URL` |
 | `--slack` | AG-009 |
 | `--webhook` | AG-010 |
 | `--health` | AG-011 score |

--- a/internal/agent/notify/discord/discord.go
+++ b/internal/agent/notify/discord/discord.go
@@ -1,0 +1,202 @@
+// Package discord POSTs gated AgentAlerts to Discord webhooks.
+//
+// Credentials come from the environment (mounted from a Kubernetes Secret in-cluster):
+//
+//	KPROMPT_DISCORD_WEBHOOK_URL — Discord incoming webhook URL
+//
+// Retries transient failures; callers should log errors and keep the watch loop alive.
+// Webhook URLs are credentials; never log them.
+package discord
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kprompt/kprompt/internal/incident"
+)
+
+const EnvWebhookURL = "KPROMPT_DISCORD_WEBHOOK_URL"
+
+const (
+	defaultAttempts = 3
+	defaultBackoff  = 500 * time.Millisecond
+)
+
+// Config holds Discord destination settings.
+type Config struct {
+	URL        string
+	Attempts   int
+	Backoff    time.Duration
+	HTTPClient *http.Client
+}
+
+// ConfigFromEnv loads Discord settings from process env (Secret -> env in the agent pod).
+func ConfigFromEnv() Config {
+	return Config{URL: firstEnv(EnvWebhookURL, "DISCORD_WEBHOOK_URL")}
+}
+
+// Enabled reports whether a URL is configured.
+func (c Config) Enabled() bool {
+	return strings.TrimSpace(c.URL) != ""
+}
+
+// Client posts AgentAlert text to Discord.
+type Client struct {
+	cfg Config
+}
+
+// New returns a Discord client with retry defaults.
+func New(cfg Config) *Client {
+	if cfg.Attempts <= 0 {
+		cfg.Attempts = defaultAttempts
+	}
+	if cfg.Backoff <= 0 {
+		cfg.Backoff = defaultBackoff
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &Client{cfg: cfg}
+}
+
+// Notify POSTs the AgentAlert as a Discord webhook message.
+func (c *Client) Notify(ctx context.Context, alert incident.AgentAlert) error {
+	if c == nil {
+		return fmt.Errorf("discord: client is nil")
+	}
+	if !c.cfg.Enabled() {
+		return fmt.Errorf("discord: %s is required", EnvWebhookURL)
+	}
+	if err := incident.ValidateAgentAlert(alert); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(payloadFor(alert))
+	if err != nil {
+		return err
+	}
+	return c.postWithRetry(ctx, raw)
+}
+
+func (c *Client) postWithRetry(ctx context.Context, raw []byte) error {
+	var last error
+	backoff := c.cfg.Backoff
+	for attempt := 1; attempt <= c.cfg.Attempts; attempt++ {
+		last = c.postOnce(ctx, raw)
+		if last == nil {
+			return nil
+		}
+		if attempt == c.cfg.Attempts || ctx.Err() != nil {
+			break
+		}
+		if !retryable(last) {
+			return last
+		}
+		t := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return ctx.Err()
+		case <-t.C:
+		}
+		backoff *= 2
+	}
+	return fmt.Errorf("discord: after %d attempts: %w", c.cfg.Attempts, last)
+}
+
+func (c *Client) postOnce(ctx context.Context, raw []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.URL, bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "kprompt-agent/observe")
+
+	res, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return &transientError{err: err}
+	}
+	defer res.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return nil
+	}
+	msg := fmt.Sprintf("webhook HTTP %d: %s", res.StatusCode, truncate(string(respBody), 200))
+	if res.StatusCode == 429 || res.StatusCode >= 500 {
+		return &transientError{err: fmt.Errorf("%s", msg)}
+	}
+	return fmt.Errorf("discord: %s", msg)
+}
+
+type transientError struct{ err error }
+
+func (e *transientError) Error() string { return e.err.Error() }
+func (e *transientError) Unwrap() error { return e.err }
+
+func retryable(err error) bool {
+	_, ok := err.(*transientError)
+	return ok
+}
+
+type webhookPayload struct {
+	Content         string          `json:"content"`
+	Username        string          `json:"username,omitempty"`
+	AllowedMentions allowedMentions `json:"allowed_mentions"`
+}
+
+type allowedMentions struct {
+	Parse []string `json:"parse"`
+}
+
+func payloadFor(a incident.AgentAlert) webhookPayload {
+	return webhookPayload{
+		Content:         truncate(FormatAlert(a), 2000),
+		Username:        "kprompt Observe",
+		AllowedMentions: allowedMentions{Parse: []string{}},
+	}
+}
+
+// FormatAlert renders a compact Discord markdown message from AgentAlert.
+func FormatAlert(a incident.AgentAlert) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**%s** - `%s`\n", a.Namespace, a.Status)
+	fmt.Fprintf(&b, "**Summary:** %s\n", a.Summary)
+	fmt.Fprintf(&b, "**Severity:** %s - **Confidence:** %.0f%%\n", a.Severity, a.Confidence*100)
+	if a.RootCause != "" {
+		fmt.Fprintf(&b, "**Reason:** %s\n", a.RootCause)
+	}
+	if a.Recommendation != "" {
+		fmt.Fprintf(&b, "**Recommendation:** %s\n", a.Recommendation)
+	}
+	if len(a.Affected) > 0 {
+		parts := make([]string, 0, len(a.Affected))
+		for _, r := range a.Affected {
+			parts = append(parts, r.Kind+"/"+r.Name)
+		}
+		fmt.Fprintf(&b, "**Affected:** %s\n", strings.Join(parts, ", "))
+	}
+	fmt.Fprintf(&b, "_incident %s - kprompt Observe_", a.IncidentID)
+	return b.String()
+}
+
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/agent/notify/discord/discord_test.go
+++ b/internal/agent/notify/discord/discord_test.go
@@ -1,0 +1,135 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kprompt/kprompt/internal/incident"
+)
+
+func TestFormatAlert(t *testing.T) {
+	text := FormatAlert(sampleAlert())
+	for _, want := range []string{"payments", "fired", "CrashLoopBackOff", "90%", "Redis DNS", "payment-api", "inc-42"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in:\n%s", want, text)
+		}
+	}
+}
+
+func TestNotifySuccess(t *testing.T) {
+	var got webhookPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method=%s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("content-type %s", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Notify(context.Background(), sampleAlert()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.Content, "CrashLoopBackOff") || !strings.Contains(got.Content, "inc-42") {
+		t.Fatalf("content=%q", got.Content)
+	}
+	if len(got.AllowedMentions.Parse) != 0 {
+		t.Fatalf("allowed mentions should be disabled: %+v", got.AllowedMentions)
+	}
+}
+
+func TestNotifyRequiresWebhookURL(t *testing.T) {
+	err := New(Config{}).Notify(context.Background(), sampleAlert())
+	if err == nil || !strings.Contains(err.Error(), EnvWebhookURL) {
+		t.Fatalf("expected %s error, got %v", EnvWebhookURL, err)
+	}
+}
+
+func TestNotifyRetriesThenSucceeds(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) < 3 {
+			w.WriteHeader(503)
+			_, _ = w.Write([]byte("busy"))
+			return
+		}
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		URL:        srv.URL,
+		Attempts:   3,
+		Backoff:    10 * time.Millisecond,
+		HTTPClient: srv.Client(),
+	})
+	if err := c.Notify(context.Background(), sampleAlert()); err != nil {
+		t.Fatal(err)
+	}
+	if n.Load() != 3 {
+		t.Fatalf("attempts=%d", n.Load())
+	}
+}
+
+func TestNotifyNoRetryOn400(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n.Add(1)
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte("bad request"))
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		URL:        srv.URL,
+		Attempts:   3,
+		Backoff:    time.Millisecond,
+		HTTPClient: srv.Client(),
+	})
+	err := c.Notify(context.Background(), sampleAlert())
+	if err == nil || !strings.Contains(err.Error(), "webhook HTTP 400") {
+		t.Fatalf("expected webhook HTTP 400 error, got %v", err)
+	}
+	if strings.Contains(err.Error(), srv.URL) {
+		t.Fatalf("error leaked webhook URL: %v", err)
+	}
+	if n.Load() != 1 {
+		t.Fatalf("expected single attempt, got %d", n.Load())
+	}
+}
+
+func TestConfigEnabled(t *testing.T) {
+	if (Config{}).Enabled() {
+		t.Fatal("empty")
+	}
+	if !(Config{URL: "https://discord.com/api/webhooks/x/y"}).Enabled() {
+		t.Fatal("webhook")
+	}
+}
+
+func sampleAlert() incident.AgentAlert {
+	return incident.NewAgentAlert(incident.Incident{
+		ID:             "inc-42",
+		Namespace:      "payments",
+		Severity:       incident.SeverityHigh,
+		Confidence:     0.9,
+		Summary:        "CrashLoopBackOff",
+		RootCause:      "Redis DNS timeout",
+		Recommendation: "Check redis-service",
+		Affected:       []incident.ResourceRef{{Kind: "Deployment", Name: "payment-api"}},
+	}, incident.AlertFired, time.Now().UTC())
+}


### PR DESCRIPTION
## Summary

Closes #83

Adds a Discord webhook notify adapter for gated Observe Agent alerts.

## Changes

- Add Discord notify adapter under `internal/agent/notify/discord`
- Post formatted gated `AgentAlert` markdown messages to Discord incoming webhooks
- Introduce CLI flags: `--discord`, `--discord-webhook-url`
- Support environment variable `KPROMPT_DISCORD_WEBHOOK_URL`
- Update agent documentation (`docs/agent.md`, `docs/agent-ops.md`)
- Add httptest unit tests covering success, exponential backoff retry, and non-retryable client errors

## Test plan

```sh
go test ./internal/agent/notify/discord -v
go test ./cmd/kprompt -run Test -count=1