### PR TITLE
feat(agent): wire Discord notify through Helm and CRD

### DIFF
--- a/api/v1/kpromptagent_types.go
+++ b/api/v1/kpromptagent_types.go
@@ -52,6 +52,7 @@ type LLMSpec struct {
 type NotifySpec struct {
 	Slack   bool `json:"slack,omitempty"`
 	Webhook bool `json:"webhook,omitempty"`
+	Discord bool `json:"discord,omitempty"`
 }
 
 // SeveritySpec configures the alert gate.

--- a/charts/kprompt-agent/README.md
+++ b/charts/kprompt-agent/README.md
@@ -23,11 +23,13 @@ docker push ghcr.io/kprompt/kprompt:dev
 kubectl -n payments create secret generic kprompt-agent \
   --from-literal=OPENAI_API_KEY=sk-... \
   --from-literal=KPROMPT_SLACK_BOT_TOKEN=xoxb-... \
-  --from-literal=KPROMPT_SLACK_CHANNEL=C...
+  --from-literal=KPROMPT_SLACK_CHANNEL=C... \
+  --from-literal=KPROMPT_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
 
 helm upgrade --install kprompt-agent ./charts/kprompt-agent \
   -n payments --create-namespace \
   --set image.tag=dev \
+  --set agent.discord=true \
   --set agent.slack=true
 ```
 
@@ -49,7 +51,7 @@ helm upgrade --install kprompt-agent ./charts/kprompt-agent \
 | `agent.autopilotPropose` | `false` | ADR-0015 propose-only (never apply by itself) |
 | `agent.autopilotApply` | `false` | AG-042 in-loop apply (needs policyAuto) |
 | `agent.remediationPolicy` | `false` | AG-040 create proposeOnly ConfigMap |
-| `agent.slack` / `agent.webhook` | `false` | Enable notifiers |
+| `agent.discord` / `agent.slack` / `agent.webhook` | `false` | Enable notifiers |
 | `secret.name` | `kprompt-agent` | Env-from Secret |
 | `rbac.create` | `true` | Namespace Role (get/list/watch) |
 | `agentCR.name` | `""` | Patch `KpromptAgent.status` (AG-013) |

--- a/charts/kprompt-agent/crds/kprompt.ai_kpromptagents.yaml
+++ b/charts/kprompt-agent/crds/kprompt.ai_kpromptagents.yaml
@@ -82,6 +82,9 @@ spec:
                 notify:
                   type: object
                   properties:
+                    discord:
+                      type: boolean
+                      default: false
                     slack:
                       type: boolean
                       default: false
@@ -108,7 +111,7 @@ spec:
                   default: true
                 secretRef:
                   type: object
-                  description: Secret providing LLM / Slack / webhook credentials.
+                  description: Secret providing LLM / Discord / Slack / webhook credentials.
                   properties:
                     name:
                       type: string

--- a/charts/kprompt-agent/templates/deployment.yaml
+++ b/charts/kprompt-agent/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
             {{- if .Values.agent.heuristic }}
             - --heuristic
             {{- end }}
+            {{- if .Values.agent.discord }}
+            - --discord
+            {{- end }}
             {{- if .Values.agent.slack }}
             - --slack
             {{- end }}

--- a/charts/kprompt-agent/templates/kpromptagent.yaml
+++ b/charts/kprompt-agent/templates/kpromptagent.yaml
@@ -20,6 +20,7 @@ spec:
     {{- end }}
     heuristic: {{ .Values.agentCR.llm.heuristic | default false }}
   notify:
+    discord: {{ .Values.agentCR.notify.discord | default false }}
     slack: {{ .Values.agentCR.notify.slack | default false }}
     webhook: {{ .Values.agentCR.notify.webhook | default false }}
   severity:

--- a/charts/kprompt-agent/values.yaml
+++ b/charts/kprompt-agent/values.yaml
@@ -28,6 +28,7 @@ agent:
   health: true
   # Prefer LLM when provider secrets exist; set true for offline demos.
   heuristic: false
+  discord: false
   slack: false
   webhook: false
   # AG-015: discover deps into analyzer context (file or configmap backend).
@@ -62,6 +63,7 @@ secret:
   # Optional stringData when create=true (do not commit real values).
   stringData: {}
   #   OPENAI_API_KEY: ""
+  #   KPROMPT_DISCORD_WEBHOOK_URL: ""
   #   KPROMPT_SLACK_BOT_TOKEN: ""
   #   KPROMPT_SLACK_CHANNEL: ""
   #   KPROMPT_SLACK_WEBHOOK_URL: ""
@@ -104,6 +106,7 @@ agentCR:
     model: ""
     heuristic: false
   notify:
+    discord: false
     slack: false
     webhook: false
   severity:

--- a/cmd/kprompt/agent.go
+++ b/cmd/kprompt/agent.go
@@ -660,7 +660,7 @@ Pipeline flags (read-only — never mutate workload objects):
   --fetch-logs     on-demand log tail on CrashLoop/Failed/OOM
   --build-context  assemble AgentContext
   --analyze        LLM/heuristic → gated AgentAlert
-  --discord       post gated alerts to Discord webhook
+  --discord        post gated alerts to Discord webhook
   --slack          post gated alerts to Slack threads
   --webhook        POST gated AgentAlert JSON to a URL
   --health         emit namespace health score / risk_increasing

--- a/cmd/kprompt/agent.go
+++ b/cmd/kprompt/agent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kprompt/kprompt/internal/agent/health"
 	agentlogs "github.com/kprompt/kprompt/internal/agent/logs"
 	"github.com/kprompt/kprompt/internal/agent/memory"
+	agentdiscord "github.com/kprompt/kprompt/internal/agent/notify/discord"
 	agentslack "github.com/kprompt/kprompt/internal/agent/notify/slack"
 	"github.com/kprompt/kprompt/internal/agent/notify/slack/ask"
 	agentwebhook "github.com/kprompt/kprompt/internal/agent/notify/webhook"
@@ -613,6 +614,8 @@ func newAgentRunCmd() *cobra.Command {
 		buildContext     bool
 		doAnalyze        bool
 		heuristic        bool
+		notifyDiscord    bool
+		discordURL       string
 		notifySlack      bool
 		notifyWebhook    bool
 		webhookURL       string
@@ -657,6 +660,7 @@ Pipeline flags (read-only — never mutate workload objects):
   --fetch-logs     on-demand log tail on CrashLoop/Failed/OOM
   --build-context  assemble AgentContext
   --analyze        LLM/heuristic → gated AgentAlert
+  --discord       post gated alerts to Discord webhook
   --slack          post gated alerts to Slack threads
   --webhook        POST gated AgentAlert JSON to a URL
   --health         emit namespace health score / risk_increasing
@@ -692,6 +696,9 @@ Slack credentials from env / mounted Secret:
 Generic webhook:
   KPROMPT_WEBHOOK_URL  or  --webhook-url
 
+Discord:
+  KPROMPT_DISCORD_WEBHOOK_URL  or  --discord-webhook-url
+
 KpromptAgent status sync:
   --agent-cr / KPROMPT_AGENT_CR  (+ optional --agent-cr-namespace)`,
 		Example: `  kprompt agent run -n payments --health --heuristic
@@ -708,7 +715,7 @@ KpromptAgent status sync:
 				trackHealth = true
 				doAnalyze = true
 			}
-			if notifySlack || notifyWebhook {
+			if notifyDiscord || notifySlack || notifyWebhook {
 				doAnalyze = true
 			}
 			if trackHealth && !incidents {
@@ -751,6 +758,7 @@ KpromptAgent status sync:
 			var fetcher *agentlogs.Fetcher
 			var ctxBuilder *ctxbuild.Builder
 			var analyzer *analyze.Analyzer
+			var discordClient *agentdiscord.Client
 			var slackClient *agentslack.Client
 			var webhookClient *agentwebhook.Client
 			var healthTracker *health.Tracker
@@ -888,6 +896,16 @@ KpromptAgent status sync:
 					analyzer.Patterns = patterns.New(pstore)
 				}
 			}
+			if notifyDiscord {
+				dcfg := agentdiscord.ConfigFromEnv()
+				if u := strings.TrimSpace(discordURL); u != "" {
+					dcfg.URL = u
+				}
+				if !dcfg.Enabled() {
+					return fmt.Errorf("--discord requires %s or --discord-webhook-url", agentdiscord.EnvWebhookURL)
+				}
+				discordClient = agentdiscord.New(dcfg)
+			}
 			if notifySlack {
 				scfg := agentslack.ConfigFromEnv()
 				if !scfg.Enabled() {
@@ -976,6 +994,11 @@ KpromptAgent status sync:
 						if webhookClient != nil && outcome.PassedGate {
 							if err := webhookClient.Notify(cmd.Context(), outcome.Alert); err != nil {
 								fmt.Fprintf(cmd.ErrOrStderr(), "webhook notify error: %v\n", err)
+							}
+						}
+						if discordClient != nil && outcome.PassedGate {
+							if err := discordClient.Notify(cmd.Context(), outcome.Alert); err != nil {
+								fmt.Fprintf(cmd.ErrOrStderr(), "discord notify error: %v\n", err)
 							}
 						}
 						if statusSync != nil && outcome.PassedGate {
@@ -1168,7 +1191,7 @@ KpromptAgent status sync:
 
 			mode := "Pods+Events"
 			switch {
-			case notifySlack || notifyWebhook:
+			case notifyDiscord || notifySlack || notifyWebhook:
 				mode = "watch → analyze → notify"
 			case doAnalyze:
 				mode = "watch → incidents → context → analyze"
@@ -1259,6 +1282,8 @@ KpromptAgent status sync:
 	cmd.Flags().BoolVar(&fetchLogs, "fetch-logs", false, "on CrashLoop/Failed/OOM attach a short log tail (enables --incidents)")
 	cmd.Flags().BoolVar(&buildContext, "build-context", false, "assemble AgentContext for LLM (enables --incidents)")
 	cmd.Flags().BoolVar(&doAnalyze, "analyze", false, "run LLM/heuristic analyzer → gated AgentAlert")
+	cmd.Flags().BoolVar(&notifyDiscord, "discord", false, "post gated alerts to Discord webhook (enables --analyze)")
+	cmd.Flags().StringVar(&discordURL, "discord-webhook-url", "", "override KPROMPT_DISCORD_WEBHOOK_URL for --discord")
 	cmd.Flags().BoolVar(&notifySlack, "slack", false, "post gated alerts to Slack (enables --analyze)")
 	cmd.Flags().BoolVar(&notifyWebhook, "webhook", false, "POST gated AgentAlert JSON to webhook URL (enables --analyze)")
 	cmd.Flags().StringVar(&webhookURL, "webhook-url", "", "override KPROMPT_WEBHOOK_URL for --webhook")

--- a/config/samples/kpromptagent.yaml
+++ b/config/samples/kpromptagent.yaml
@@ -13,6 +13,7 @@ spec:
     provider: openai
     heuristic: false
   notify:
+    discord: false
     slack: false
     webhook: false
   severity:

--- a/deploy/crd/kprompt.ai_kpromptagents.yaml
+++ b/deploy/crd/kprompt.ai_kpromptagents.yaml
@@ -82,6 +82,9 @@ spec:
                 notify:
                   type: object
                   properties:
+                     discord:
+                      type: boolean
+                      default: false
                     slack:
                       type: boolean
                       default: false
@@ -108,7 +111,7 @@ spec:
                   default: true
                 secretRef:
                   type: object
-                  description: Secret providing LLM / Slack / webhook credentials.
+                  description: Secret providing LLM / Discord / Slack / webhook credentials.
                   properties:
                     name:
                       type: string

--- a/deploy/crd/kprompt.ai_kpromptagents.yaml
+++ b/deploy/crd/kprompt.ai_kpromptagents.yaml
@@ -82,7 +82,7 @@ spec:
                 notify:
                   type: object
                   properties:
-                     discord:
+                    discord:
                       type: boolean
                       default: false
                     slack:

--- a/docs/agent-ops.md
+++ b/docs/agent-ops.md
@@ -7,7 +7,7 @@ Companion: [agent.md](./agent.md) · [namespace-agent.md](./namespace-agent.md) 
 ## Install checklist
 
 1. Pick **one watch namespace** (or one agent Deployment per ns).
-2. Create Secret for LLM + Slack/webhook (never put keys in values/CRD plaintext).
+2. Create Secret for LLM + Discord/Slack/webhook (never put keys in values/CRD plaintext).
 3. `helm upgrade --install` with image your cluster can pull.
 4. Confirm Role is namespaced: `kubectl -n <ns> get role,rolebinding,sa -l app.kubernetes.io/name=kprompt-agent`.
 5. Tail agent logs; expect `watching namespace … (read-only)`.
@@ -42,6 +42,7 @@ Argo CD Applications often live in `argocd`, not the app ns — `--gitops-eviden
 | `--min-severity` / `--min-confidence` | Defaults medium / 0.7 — raise to cut noise |
 | Incident batching | One LLM call per evidence fingerprint, not per raw Event |
 | `--patterns` | Local disk/CM; no cloud upload; dampens repeat analysis quality issues |
+| Discord webhook | Simple gated alert posts; keep webhook URL in Secret |
 | Slack threads | Prefer bot token + channel over webhook for update-in-thread |
 | Prom / OTel | Optional; missing → `degraded:` — no invented metrics |
 
@@ -63,6 +64,7 @@ All of the above stay **local / in-cluster** — not uploaded to `api.kprompt.ai
 | Symptom | Check |
 |---------|--------|
 | No alerts | Gate (`min-severity` / `min-confidence`); is `--analyze` on? Open incidents? |
+| Discord silent | `--discord` plus `KPROMPT_DISCORD_WEBHOOK_URL` or `--discord-webhook-url`; check webhook permissions |
 | `degraded: prometheus\|otel\|gitops` | Backend URL / CRDs / RBAC; expected when opt-in signal missing |
 | Slack ask silent | `--slack-ask` + bot token; Events API URL / port-forward to `--slack-ask-addr` |
 | False-positive learning no-op | Need `--patterns` with ask callback |
@@ -72,7 +74,7 @@ All of the above stay **local / in-cluster** — not uploaded to `api.kprompt.ai
 
 ## Security hygiene
 
-- Rotate provider + Slack tokens via Secret; restart Deployment.
+- Rotate provider + Discord/Slack webhook URLs and tokens via Secret; restart Deployment.
 - Never enable Secret **value** reads (agent does not support it).
 - Treat InvestigationReport / Slack text as sensitive (may include log snippets).
 - Autopilot propose audit files may name workloads — protect laptop paths in shared demos.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,6 +1,6 @@
 # kprompt Observe agent
 
-In-cluster, **namespace-scoped** agent that continuously watches Pods/Events (and optional workloads), correlates incidents, optionally analyzes with an LLM, and notifies Slack/webhooks.
+In-cluster, **namespace-scoped** agent that continuously watches Pods/Events (and optional workloads), correlates incidents, optionally analyzes with an LLM, and notifies Discord, Slack, or webhooks.
 
 This is **Observe Mode** by default — it never applies, patches, or deletes cluster resources ([ADR-0013](https://github.com/kprompt/kprompt-architecture/blob/main/decisions/ADR-0013-in-cluster-agent.md)). Optional `--autopilot-propose` emits PlanResult-shaped proposals only ([ADR-0015](https://github.com/kprompt/kprompt-architecture/blob/main/decisions/ADR-0015-autopilot-mode.md)); **apply** stays gated. The Namespace Agent continuous-intelligence contract is [ADR-0016](https://github.com/kprompt/kprompt-architecture/blob/main/decisions/ADR-0016-namespace-agent.md).
 
@@ -42,7 +42,7 @@ Default install is a **Role + RoleBinding in one namespace** (get/list/watch on 
 
 ## LLM cost
 
-- The agent does **not** call the LLM on every raw API event. It batches by open **Incident**, then applies a **severity + confidence gate** before Slack/webhook.
+- The agent does **not** call the LLM on every raw API event. It batches by open **Incident**, then applies a **severity + confidence gate** before Discord/Slack/webhook.
 - Prefer `--heuristic` for demos / offline; turn LLM on when you accept API spend.
 - Gate tighter with `--min-severity` / `--min-confidence` (defaults: medium / 0.7) to limit alert fatigue and token burn.
 - Credentials stay in a **Secret** (`envFrom`) — never in CRD/ConfigMap plaintext.
@@ -52,6 +52,7 @@ Default install is a **Role + RoleBinding in one namespace** (get/list/watch on 
 ```bash
 kprompt agent run -n payments --analyze --fetch-logs --health --heuristic
 kprompt agent run -n payments --slack --fetch-logs   # needs Slack env
+kprompt agent run -n payments --discord --fetch-logs # needs Discord webhook env
 ```
 
 Need a namespace that actually misbehaves? [kprompt-examples](https://github.com/kprompt/kprompt-examples) provisions a kind cluster plus seven failure scenarios (crashloop, image pull, OOM, stalled rollout, unbound PVC, failing CronJob, missing dependency), each documenting what the agent is expected to conclude:
@@ -157,6 +158,7 @@ Chart: [`charts/kprompt-operator`](../charts/kprompt-operator).
 | Env key | Purpose |
 |---------|---------|
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / … | LLM (same as CLI) |
+| `KPROMPT_DISCORD_WEBHOOK_URL` | Discord webhook URL for gated AgentAlert text |
 | `KPROMPT_SLACK_BOT_TOKEN` + `KPROMPT_SLACK_CHANNEL` | Threaded Slack (preferred) |
 | `KPROMPT_SLACK_WEBHOOK_URL` | Slack webhook fallback |
 | `KPROMPT_WEBHOOK_URL` | Generic AgentAlert JSON POST |
@@ -216,6 +218,8 @@ Secrets are never watched implicitly and only metadata (type + key count) is emi
 | `--fetch-logs` | AG-005 on-demand logs |
 | `--build-context` | AG-007 context |
 | `--analyze` | AG-008 gated AgentAlert |
+| `--discord` | Discord webhook gated alerts |
+| `--discord-webhook-url` | Override `KPROMPT_DISCORD_WEBHOOK_URL` |
 | `--slack` | AG-009 |
 | `--webhook` | AG-010 |
 | `--health` | AG-011 score |

--- a/docs/namespace-agent.md
+++ b/docs/namespace-agent.md
@@ -19,7 +19,7 @@ Contracts: [ADR-0013](https://github.com/kprompt/kprompt-architecture/blob/main/
 
 ```text
 ┌─────────────────────┐     InvestigationReport v2      ┌──────────────────┐
-│  Namespace Agent    │ ── Slack / webhook / ask ──────► │  Humans / SIEM   │
+│  Namespace Agent    │ ── Slack / Discord / webhook / ask ──► │  Humans / SIEM   │
 │  (Role, one ns)     │                                  └──────────────────┘
 │                     │  Suspect outside my ns?
 │                     │ ── CoordinatorHandoff ─────────► ┌──────────────────┐
@@ -57,7 +57,7 @@ Contracts: [ADR-0013](https://github.com/kprompt/kprompt-architecture/blob/main/
 |------------|----------------|------|
 | Watch + incidents + health | `--incidents --health` | Observe |
 | LLM / heuristic alert | `--analyze` | Observe → NA |
-| Slack / webhook | `--slack` / `--webhook` | Observe |
+| Slack / Discord / webhook | `--slack` / `--discord` / `--webhook` | Observe |
 | Slack ask | `--slack-ask` | NA surface |
 | Memory / patterns | `--memory` / `--patterns` | NA learn |
 | Prom / OTel / GitOps evidence | env / `--gitops-evidence` | NA signals |

--- a/internal/agent/notify/discord/discord.go
+++ b/internal/agent/notify/discord/discord.go
@@ -1,0 +1,202 @@
+// Package discord POSTs gated AgentAlerts to Discord webhooks.
+//
+// Credentials come from the environment (mounted from a Kubernetes Secret in-cluster):
+//
+//	KPROMPT_DISCORD_WEBHOOK_URL — Discord incoming webhook URL
+//
+// Retries transient failures; callers should log errors and keep the watch loop alive.
+// Webhook URLs are credentials; never log them.
+package discord
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kprompt/kprompt/internal/incident"
+)
+
+const EnvWebhookURL = "KPROMPT_DISCORD_WEBHOOK_URL"
+
+const (
+	defaultAttempts = 3
+	defaultBackoff  = 500 * time.Millisecond
+)
+
+// Config holds Discord destination settings.
+type Config struct {
+	URL        string
+	Attempts   int
+	Backoff    time.Duration
+	HTTPClient *http.Client
+}
+
+// ConfigFromEnv loads Discord settings from process env (Secret -> env in the agent pod).
+func ConfigFromEnv() Config {
+	return Config{URL: firstEnv(EnvWebhookURL, "DISCORD_WEBHOOK_URL")}
+}
+
+// Enabled reports whether a URL is configured.
+func (c Config) Enabled() bool {
+	return strings.TrimSpace(c.URL) != ""
+}
+
+// Client posts AgentAlert text to Discord.
+type Client struct {
+	cfg Config
+}
+
+// New returns a Discord client with retry defaults.
+func New(cfg Config) *Client {
+	if cfg.Attempts <= 0 {
+		cfg.Attempts = defaultAttempts
+	}
+	if cfg.Backoff <= 0 {
+		cfg.Backoff = defaultBackoff
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &Client{cfg: cfg}
+}
+
+// Notify POSTs the AgentAlert as a Discord webhook message.
+func (c *Client) Notify(ctx context.Context, alert incident.AgentAlert) error {
+	if c == nil {
+		return fmt.Errorf("discord: client is nil")
+	}
+	if !c.cfg.Enabled() {
+		return fmt.Errorf("discord: %s is required", EnvWebhookURL)
+	}
+	if err := incident.ValidateAgentAlert(alert); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(payloadFor(alert))
+	if err != nil {
+		return err
+	}
+	return c.postWithRetry(ctx, raw)
+}
+
+func (c *Client) postWithRetry(ctx context.Context, raw []byte) error {
+	var last error
+	backoff := c.cfg.Backoff
+	for attempt := 1; attempt <= c.cfg.Attempts; attempt++ {
+		last = c.postOnce(ctx, raw)
+		if last == nil {
+			return nil
+		}
+		if attempt == c.cfg.Attempts || ctx.Err() != nil {
+			break
+		}
+		if !retryable(last) {
+			return last
+		}
+		t := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return ctx.Err()
+		case <-t.C:
+		}
+		backoff *= 2
+	}
+	return fmt.Errorf("discord: after %d attempts: %w", c.cfg.Attempts, last)
+}
+
+func (c *Client) postOnce(ctx context.Context, raw []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.URL, bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "kprompt-agent/observe")
+
+	res, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return &transientError{err: err}
+	}
+	defer res.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return nil
+	}
+	msg := fmt.Sprintf("webhook HTTP %d: %s", res.StatusCode, truncate(string(respBody), 200))
+	if res.StatusCode == 429 || res.StatusCode >= 500 {
+		return &transientError{err: fmt.Errorf("%s", msg)}
+	}
+	return fmt.Errorf("discord: %s", msg)
+}
+
+type transientError struct{ err error }
+
+func (e *transientError) Error() string { return e.err.Error() }
+func (e *transientError) Unwrap() error { return e.err }
+
+func retryable(err error) bool {
+	_, ok := err.(*transientError)
+	return ok
+}
+
+type webhookPayload struct {
+	Content         string          `json:"content"`
+	Username        string          `json:"username,omitempty"`
+	AllowedMentions allowedMentions `json:"allowed_mentions"`
+}
+
+type allowedMentions struct {
+	Parse []string `json:"parse"`
+}
+
+func payloadFor(a incident.AgentAlert) webhookPayload {
+	return webhookPayload{
+		Content:         truncate(FormatAlert(a), 2000),
+		Username:        "kprompt Observe",
+		AllowedMentions: allowedMentions{Parse: []string{}},
+	}
+}
+
+// FormatAlert renders a compact Discord markdown message from AgentAlert.
+func FormatAlert(a incident.AgentAlert) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**%s** - `%s`\n", a.Namespace, a.Status)
+	fmt.Fprintf(&b, "**Summary:** %s\n", a.Summary)
+	fmt.Fprintf(&b, "**Severity:** %s - **Confidence:** %.0f%%\n", a.Severity, a.Confidence*100)
+	if a.RootCause != "" {
+		fmt.Fprintf(&b, "**Reason:** %s\n", a.RootCause)
+	}
+	if a.Recommendation != "" {
+		fmt.Fprintf(&b, "**Recommendation:** %s\n", a.Recommendation)
+	}
+	if len(a.Affected) > 0 {
+		parts := make([]string, 0, len(a.Affected))
+		for _, r := range a.Affected {
+			parts = append(parts, r.Kind+"/"+r.Name)
+		}
+		fmt.Fprintf(&b, "**Affected:** %s\n", strings.Join(parts, ", "))
+	}
+	fmt.Fprintf(&b, "_incident %s - kprompt Observe_", a.IncidentID)
+	return b.String()
+}
+
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/agent/notify/discord/discord_test.go
+++ b/internal/agent/notify/discord/discord_test.go
@@ -1,0 +1,135 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kprompt/kprompt/internal/incident"
+)
+
+func TestFormatAlert(t *testing.T) {
+	text := FormatAlert(sampleAlert())
+	for _, want := range []string{"payments", "fired", "CrashLoopBackOff", "90%", "Redis DNS", "payment-api", "inc-42"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in:\n%s", want, text)
+		}
+	}
+}
+
+func TestNotifySuccess(t *testing.T) {
+	var got webhookPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method=%s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("content-type %s", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Notify(context.Background(), sampleAlert()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.Content, "CrashLoopBackOff") || !strings.Contains(got.Content, "inc-42") {
+		t.Fatalf("content=%q", got.Content)
+	}
+	if len(got.AllowedMentions.Parse) != 0 {
+		t.Fatalf("allowed mentions should be disabled: %+v", got.AllowedMentions)
+	}
+}
+
+func TestNotifyRequiresWebhookURL(t *testing.T) {
+	err := New(Config{}).Notify(context.Background(), sampleAlert())
+	if err == nil || !strings.Contains(err.Error(), EnvWebhookURL) {
+		t.Fatalf("expected %s error, got %v", EnvWebhookURL, err)
+	}
+}
+
+func TestNotifyRetriesThenSucceeds(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) < 3 {
+			w.WriteHeader(503)
+			_, _ = w.Write([]byte("busy"))
+			return
+		}
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		URL:        srv.URL,
+		Attempts:   3,
+		Backoff:    10 * time.Millisecond,
+		HTTPClient: srv.Client(),
+	})
+	if err := c.Notify(context.Background(), sampleAlert()); err != nil {
+		t.Fatal(err)
+	}
+	if n.Load() != 3 {
+		t.Fatalf("attempts=%d", n.Load())
+	}
+}
+
+func TestNotifyNoRetryOn400(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n.Add(1)
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte("bad request"))
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		URL:        srv.URL,
+		Attempts:   3,
+		Backoff:    time.Millisecond,
+		HTTPClient: srv.Client(),
+	})
+	err := c.Notify(context.Background(), sampleAlert())
+	if err == nil || !strings.Contains(err.Error(), "webhook HTTP 400") {
+		t.Fatalf("expected webhook HTTP 400 error, got %v", err)
+	}
+	if strings.Contains(err.Error(), srv.URL) {
+		t.Fatalf("error leaked webhook URL: %v", err)
+	}
+	if n.Load() != 1 {
+		t.Fatalf("expected single attempt, got %d", n.Load())
+	}
+}
+
+func TestConfigEnabled(t *testing.T) {
+	if (Config{}).Enabled() {
+		t.Fatal("empty")
+	}
+	if !(Config{URL: "https://discord.com/api/webhooks/x/y"}).Enabled() {
+		t.Fatal("webhook")
+	}
+}
+
+func sampleAlert() incident.AgentAlert {
+	return incident.NewAgentAlert(incident.Incident{
+		ID:             "inc-42",
+		Namespace:      "payments",
+		Severity:       incident.SeverityHigh,
+		Confidence:     0.9,
+		Summary:        "CrashLoopBackOff",
+		RootCause:      "Redis DNS timeout",
+		Recommendation: "Check redis-service",
+		Affected:       []incident.ResourceRef{{Kind: "Deployment", Name: "payment-api"}},
+	}, incident.AlertFired, time.Now().UTC())
+}

--- a/internal/agent/notify/webhook/webhook.go
+++ b/internal/agent/notify/webhook/webhook.go
@@ -1,6 +1,6 @@
 // Package webhook POSTs gated AgentAlert JSON to a generic HTTPS endpoint (AG-010).
 //
-// This is the adapter hook for Teams / Discord / PagerDuty / Opsgenie / Jira
+// This is the adapter hook for Teams / PagerDuty / Opsgenie / Jira
 // without coupling those vendors into the Observe core.
 //
 //	KPROMPT_WEBHOOK_URL — destination (from Secret/env)

--- a/internal/agent/operator/desired.go
+++ b/internal/agent/operator/desired.go
@@ -229,6 +229,9 @@ func agentArgs(cr *agentv1.KpromptAgent, watchNS string) []string {
 	if cr.Spec.LLM.Heuristic {
 		args = append(args, "--heuristic")
 	}
+	if cr.Spec.Notify.Discord {
+		args = append(args, "--discord")
+	}
 	if cr.Spec.Notify.Slack {
 		args = append(args, "--slack")
 	}

--- a/internal/agent/operator/desired_test.go
+++ b/internal/agent/operator/desired_test.go
@@ -15,7 +15,7 @@ func TestBuildDesiredObserve(t *testing.T) {
 		Spec: agentv1.KpromptAgentSpec{
 			Mode:      agentv1.ModeObserve,
 			LLM:       agentv1.LLMSpec{Provider: "openai", Heuristic: true},
-			Notify:    agentv1.NotifySpec{Slack: true},
+			Notify:    agentv1.NotifySpec{Slack: true, Discord: true},
 			SecretRef: &agentv1.SecretRef{Name: "kprompt-agent"},
 			Watches:   []string{"pods", "events", "deployments"},
 		},

--- a/internal/agent/operator/desired_test.go
+++ b/internal/agent/operator/desired_test.go
@@ -32,7 +32,7 @@ func TestBuildDesiredObserve(t *testing.T) {
 	for _, a := range args {
 		joined += a + " "
 	}
-	for _, want := range []string{"--in-cluster", "--heuristic", "--slack", "--watch", "--agent-cr"} {
+	for _, want := range []string{"--in-cluster", "--heuristic", "--slack", "--discord", "--watch", "--agent-cr"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("args missing %s: %v", want, args)
 		}


### PR DESCRIPTION
## Summary

Closes #83

Add Discord notifier adapter and integrate it end-to-end through Helm, the KpromptAgent CRD, operator argument wiring, CLI flags, and documentation.

This change is a follow-up to #93.

## Changes

- Add `spec.notify.discord` boolean field to the `KpromptAgent` API type
- Implement `internal/agent/notify/discord` with retry logic and unit tests
- Wire `--discord` and `--discord-webhook-url` into the agent CLI
- Inject `--discord` from the operator when `cr.Spec.Notify.Discord=true`
- Add Helm values for `agent.discord` and `agentCR.notify.discord`
- Update Deployment and KpromptAgent Helm templates
- Update sample KpromptAgent CR and CRD manifests
- Refresh chart README, `docs/agent.md`, and `docs/agent-ops.md`

## Environment

- `KPROMPT_DISCORD_WEBHOOK_URL`
- Fallback: `DISCORD_WEBHOOK_URL`
- Store webhook URLs in Secret-backed env, not plaintext CRs or values files.

## Test plan

- [x] `go test ./internal/agent/notify/discord ./internal/agent/operator ./api/v1 ./cmd/kprompt`
- [x] `go test ./...`
- [x] `helm lint charts/kprompt-agent`
- [x] `helm template kprompt-agent charts/kprompt-agent --set agent.discord=true --set agentCR.create=true --set agentCR.name=discord-demo --set agentCR.notify.discord=true`
- [x] `git diff --check`