### PR TITLE
feat(llm): add Cerebras provider preset (P-002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ export KPROMPT_ANTHROPIC_API_KEY=sk-ant-...   # --provider anthropic
 export KPROMPT_GEMINI_API_KEY=...             # --provider gemini
 export KPROMPT_GROQ_API_KEY=...               # --provider groq
 export KPROMPT_XAI_API_KEY=...                # --provider xai (Grok)
+export KPROMPT_CEREBRAS_API_KEY=...           # --provider cerebras
 export KPROMPT_MOONSHOT_API_KEY=...           # --provider moonshot (Kimi K3)
 ```
 
@@ -331,7 +332,7 @@ See also: [GitHub Integration MVP / GitOps PR mode](./docs/gitops-pr.md). Exampl
 | `--wait` | After apply, wait for Deployment rollout, then verify |
 | `--timeout` | Timeout for `--wait` (default `5m`) |
 | `--output` / `-o` | `text` (default) or `json` (CI PlanResult) |
-| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `mistral`, `deepseek`, `moonshot`, `openrouter`, `together`, `ollama`, `openai-compatible` |
+| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `openrouter`, `together`, `ollama`, `openai-compatible` |
 | `--model` | Model id |
 | `--context` | kubeconfig context |
 | `--contexts` | Comma-separated contexts for read fan-out / per-context mutate |

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -104,7 +104,7 @@ func main() {
 	root.PersistentFlags().BoolVar(&approveEachContext, "approve-each-context", false, "apply a mutating plan to every --contexts entry (explicit; not implied by --approve)")
 	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment rollout to complete")
 	root.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for --wait (default 5m)")
-	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|mistral|deepseek|moonshot|openrouter|together|ollama|openai-compatible)")
+	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|openrouter|together|ollama|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")
 	root.PersistentFlags().StringVar(&kubeCtx, "context", "", "kubeconfig context")
 	root.PersistentFlags().StringVar(&kubeCtxs, "contexts", "", "comma-separated contexts for read fan-out / per-context mutate (aliases ok)")

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -17,6 +17,7 @@ Optional Team `kp_…` tokens (`kprompt login`) are for org policy/audit — not
 | Google Gemini | `gemini` | `KPROMPT_GEMINI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` | `gemini-2.0-flash` | AI Studio key; see free-tier notes below |
 | Groq | `groq` | `KPROMPT_GROQ_API_KEY` / `GROQ_API_KEY` | `llama-3.3-70b-versatile` | OpenAI-compatible |
 | xAI (Grok) | `xai` | `KPROMPT_XAI_API_KEY` / `XAI_API_KEY` | `grok-4.5` | OpenAI-compatible |
+| Cerebras | `cerebras` | `KPROMPT_CEREBRAS_API_KEY` / `CEREBRAS_API_KEY` | `gpt-oss-120b` | OpenAI-compatible, low-latency |
 | Mistral | `mistral` | `KPROMPT_MISTRAL_API_KEY` / `MISTRAL_API_KEY` | `mistral-small-latest` | OpenAI-compatible |
 | DeepSeek | `deepseek` | `KPROMPT_DEEPSEEK_API_KEY` / `DEEPSEEK_API_KEY` | `deepseek-chat` | OpenAI-compatible |
 | Moonshot (Kimi K3) | `moonshot` | `KPROMPT_MOONSHOT_API_KEY` / `MOONSHOT_API_KEY` | `kimi-k3` | OpenAI-compatible |
@@ -75,6 +76,10 @@ kprompt --provider groq "scale api to 3"
 # xAI / Grok
 export KPROMPT_XAI_API_KEY=...
 kprompt --provider xai "explain why api is crashlooping"
+
+# Cerebras
+export KPROMPT_CEREBRAS_API_KEY=...
+kprompt --provider cerebras "list pods"
 
 # Moonshot / Kimi K3
 export KPROMPT_MOONSHOT_API_KEY=...

--- a/internal/llm/presets.go
+++ b/internal/llm/presets.go
@@ -64,6 +64,14 @@ var Presets = []Preset{
 		HelpURL:      "https://console.x.ai/",
 	},
 	{
+		Name:         "cerebras",
+		Kind:         "openai",
+		BaseURL:      "https://api.cerebras.ai/v1",
+		DefaultModel: "gpt-oss-120b",
+		EnvKeys:      []string{"KPROMPT_CEREBRAS_API_KEY", "CEREBRAS_API_KEY"},
+		HelpURL:      "https://cloud.cerebras.ai/",
+	},
+	{
 		Name:         "mistral",
 		Kind:         "openai",
 		BaseURL:      "https://api.mistral.ai/v1",

--- a/internal/llm/presets_test.go
+++ b/internal/llm/presets_test.go
@@ -16,6 +16,7 @@ func TestLookupPresetDefaults(t *testing.T) {
 		t.Fatal("ollama should allow empty key")
 	}
 }
+
 func TestLookupPresetXAI(t *testing.T) {
 	p, ok := LookupPreset("xai")
 	if !ok {
@@ -34,9 +35,29 @@ func TestLookupPresetXAI(t *testing.T) {
 		t.Fatalf("xai env keys = %v", p.EnvKeys)
 	}
 }
+
+func TestLookupPresetCerebras(t *testing.T) {
+	p, ok := LookupPreset("cerebras")
+	if !ok {
+		t.Fatal("cerebras preset not found")
+	}
+	if p.Kind != "openai" {
+		t.Fatalf("cerebras kind = %q, want openai", p.Kind)
+	}
+	if p.BaseURL != "https://api.cerebras.ai/v1" {
+		t.Fatalf("cerebras base URL = %q", p.BaseURL)
+	}
+	if p.DefaultModel != "gpt-oss-120b" {
+		t.Fatalf("cerebras default model = %q", p.DefaultModel)
+	}
+	if len(p.EnvKeys) != 2 || p.EnvKeys[0] != "KPROMPT_CEREBRAS_API_KEY" || p.EnvKeys[1] != "CEREBRAS_API_KEY" {
+		t.Fatalf("cerebras env keys = %v", p.EnvKeys)
+	}
+}
+
 func TestSupportedNamesIncludesNewProviders(t *testing.T) {
 	s := SupportedNames()
-	for _, want := range []string{"openai", "anthropic", "gemini", "groq", "mistral", "deepseek", "moonshot", "ollama", "openrouter", "together", "xai"} {
+	for _, want := range []string{"openai", "anthropic", "gemini", "groq", "mistral", "deepseek", "moonshot", "ollama", "openrouter", "together", "xai", "cerebras"} {
 		if !contains(s, want) {
 			t.Fatalf("%q missing from %s", want, s)
 		}


### PR DESCRIPTION
## Summary

Implements the public kprompt repository portion of #53 by adding a Cerebras provider preset through the existing OpenAI-compatible adapter.

This PR covers:

- preset registration
- supported provider test update
- `--provider` CLI help
- `docs/providers.md`
- `README.md`

## Changes

Add Cerebras preset:

- kind: `openai`
- base URL: `https://api.cerebras.ai/v1`
- default model: `gpt-oss-120b`
- env keys: `KPROMPT_CEREBRAS_API_KEY`, `CEREBRAS_API_KEY`
- help URL: Cerebras Cloud

The preset reuses the existing OpenAI-compatible provider implementation. No Cerebras-specific SDK or adapter is added.

## Out of scope for this repository

- `kprompt-api`
- `kprompt-app`
- `kprompt-website`
- architecture ADR / `PROVIDER-TASKS.md` updates

## Test plan

```sh
go test ./internal/llm ./cmd/kprompt
go build ./...
git diff --check