### PR TITLE
docs: refresh outdated docs/dev.md package map (#13)

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -4,11 +4,30 @@ Architecture overview lives in the private `kprompt/kprompt-architecture` repo (
 
 ## Layout
 
+CLI and core flow:
+
 - `cmd/kprompt` — CLI entry
 - `internal/pipeline` — Prompt → Intent → Plan → Safety → Apply
-- `internal/llm` — Provider interface + OpenAI / Anthropic adapters
-- `internal/safety` — Hard deny + risk
-- `internal/executor` — Deployment scale (v0 mutation)
+- `internal/intent` / `internal/planner` — parse request and build plans
+- `internal/safety` — hard deny + risk checks (including Argo-aware gates)
+- `internal/executor` — apply mutations (Kubernetes / Argo and related runtimes)
+
+LLM providers (see also [providers.md](./providers.md)):
+
+- `internal/llm` — provider interface + OpenAI, Anthropic, Gemini, and OpenAI-compatible adapters (Ollama, Groq, xAI, …)
+
+Observe / ops packages (Investigate fleet and related commands):
+
+- `internal/audit` — read-only security / hygiene scan
+- `internal/cleanup` — unused / stale Kubernetes resource detection
+- `internal/impact` — blast-radius / consumer discovery (read-only)
+- `internal/investigate` / `internal/agent` — investigation orchestration and agent fleet
+- `internal/drift`, `internal/doctor`, `internal/optimize`, `internal/score`, `internal/why` — supporting diagnose / score / explain surfaces
+- `internal/search`, `internal/graph`, `internal/timeline`, `internal/history` — context and history helpers
+- `internal/session`, `internal/setup`, `internal/config`, `internal/cluster` — runtime config and cluster access
+- `internal/ui` / `internal/output` — presentation helpers
+
+This list is a map for first-time contributors, not every package under `internal/`. Prefer package comments and existing `docs/*.md` for depth.
 
 ## Test
 


### PR DESCRIPTION
﻿## Summary
- Update `docs/dev.md` package bullets to match current `internal/` layout
- Point at multi-provider `internal/llm` + providers doc
- Sketch observe/ops packages (audit, cleanup, impact, investigate, …)

Closes #13

## Test plan
- [ ] Package paths listed under `internal/` exist
- [ ] CONTRIBUTING readers get a usable map from Layout section
