### PR TITLE
test(safety): add SEC-002 stub-plan escalation suite

### DIFF
--- a/internal/executor/delete_test.go
+++ b/internal/executor/delete_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -113,5 +114,21 @@ func TestDeleteConfigMapAndSecret(t *testing.T) {
 	}
 	if _, err := client.CoreV1().Secrets("payments").Get(context.Background(), "orphan-secret", metav1.GetOptions{}); err == nil {
 		t.Fatal("expected Secret deleted")
+	}
+}
+
+func TestDeleteUnknownKindRejected(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	err := (&Runner{Client: client}).Apply(context.Background(), planner.ExecutionPlan{
+		Actions: []planner.Action{{
+			Op:     planner.OpDelete,
+			Object: planner.ObjectRef{Kind: "CronTab", Name: "nightly", Namespace: "default"},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected unknown delete kind to fail")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -68,6 +68,7 @@ type Deps struct {
 	IsTerminal    *bool                   // override ui.StdinIsTerminal when non-nil
 	OnResult      func(output.PlanResult) // optional per-plan completion observer
 	SkipOrgPolicy bool                    // tests: ignore Team org policy (Free CLI path)
+	BuildPlan     func(intent.Intent) (planner.ExecutionPlan, error) // tests: override planner.Build
 	// RouteSteps forces a multi-step route (recipe run / tests). When set, skips
 	// SplitRoutePrompt / recipe.TryRoute matching on cfg.Prompt.
 	RouteSteps []string
@@ -259,7 +260,11 @@ func RunWith(ctx context.Context, cfg config.Resolved, out io.Writer, deps Deps)
 		}
 	}
 
-	plan, err := planner.Build(in)
+	buildPlan := deps.BuildPlan
+	if buildPlan == nil {
+		buildPlan = planner.Build
+	}
+	plan, err := buildPlan(in)
 	if err != nil {
 		return err
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -23,8 +23,10 @@ import (
 
 	"github.com/kprompt/kprompt/internal/config"
 	"github.com/kprompt/kprompt/internal/history"
+	"github.com/kprompt/kprompt/internal/intent"
 	"github.com/kprompt/kprompt/internal/llm"
 	"github.com/kprompt/kprompt/internal/output"
+	"github.com/kprompt/kprompt/internal/planner"
 	toolgrafana "github.com/kprompt/kprompt/internal/tools/grafana"
 	toolotel "github.com/kprompt/kprompt/internal/tools/otel"
 	toolprometheus "github.com/kprompt/kprompt/internal/tools/prometheus"
@@ -873,6 +875,42 @@ func TestMutationApproveFlagSkipsPrompt(t *testing.T) {
 	dep, _ := client.AppsV1().Deployments("default").Get(context.Background(), "api", metav1.GetOptions{})
 	if *dep.Spec.Replicas != 4 {
 		t.Fatalf("replicas=%v", *dep.Spec.Replicas)
+	}
+}
+
+func TestStubPlanEscalationDeniedBeforeApply(t *testing.T) {
+	client := fake.NewSimpleClientset(deployment("api", "default", 2))
+	var out bytes.Buffer
+	err := RunWith(context.Background(), config.Resolved{
+		Approve: true,
+		Prompt:  "show pod status",
+	}, &out, Deps{
+		Provider: llm.ScaleStub("api", "default", 3),
+		Client:   client,
+		BuildPlan: func(_ intent.Intent) (planner.ExecutionPlan, error) {
+			return planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindDelete},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "Namespace", Name: "default"},
+				}},
+				Summary:          "Delete Namespace/default",
+				RequiresApproval: true,
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Refusing namespace deletion")) {
+		t.Fatalf("expected safety deny message, got:\n%s", out.String())
+	}
+	dep, err := client.AppsV1().Deployments("default").Get(context.Background(), "api", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 2 {
+		t.Fatalf("expected no apply on denied plan, replicas=%v", dep.Spec.Replicas)
 	}
 }
 

--- a/internal/safety/stub_plan_escalation_test.go
+++ b/internal/safety/stub_plan_escalation_test.go
@@ -1,0 +1,200 @@
+package safety
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kprompt/kprompt/internal/intent"
+	"github.com/kprompt/kprompt/internal/planner"
+)
+
+func TestStubPlanEscalationEvaluatePlanWithOrg(t *testing.T) {
+	cases := []struct {
+		id             string
+		plan           planner.ExecutionPlan
+		org            *OrgPolicy
+		wantDenied     bool
+		wantRisk       Risk
+		wantMsgContain string
+		promptMissRefs []string
+	}{
+		{
+			id: "SEC002-EVAL-001-from-SEC001-V1-PROMPT-011",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindDelete},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "Pod", Name: "*", Namespace: "default"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "unscoped delete",
+			promptMissRefs: []string{"SEC001-V1-PROMPT-011"},
+		},
+		{
+			id: "SEC002-EVAL-002-from-SEC001-V1-PROMPT-013",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindDelete},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "Pod", Name: "", Namespace: "default"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "unscoped delete",
+			promptMissRefs: []string{"SEC001-V1-PROMPT-013"},
+		},
+		{
+			id: "SEC002-EVAL-003-namespace-delete",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindDelete},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "Namespace", Name: "prod"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "namespace deletion",
+		},
+		{
+			id: "SEC002-EVAL-004-exotic-kind-delete",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindDelete},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "CronTab", Name: "nightly", Namespace: "default"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "Refusing delete of CronTab",
+		},
+		{
+			id: "SEC002-EVAL-005-configmap-no-confirm-orphans",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindDelete},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "ConfigMap", Name: "orphan", Namespace: "default"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "confirm_orphans",
+		},
+		{
+			id: "SEC002-EVAL-006-secret-no-confirm-orphans",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindDelete},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "Secret", Name: "orphan", Namespace: "default"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "confirm_orphans",
+		},
+		{
+			id: "SEC002-EVAL-007-hallucinated-confirm-orphans-needs-approval",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{
+					Kind:   intent.KindDelete,
+					Params: map[string]any{"confirm_orphans": true},
+				},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "ConfigMap", Name: "orphan", Namespace: "default"},
+				}},
+				RequiresApproval: true,
+			},
+			wantDenied: false,
+			wantRisk:   RiskHigh,
+		},
+		{
+			id: "SEC002-EVAL-008-hallucinated-confirm-orphans-blocked-by-org",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{
+					Kind:   intent.KindDelete,
+					Params: map[string]any{"confirm_orphans": true},
+				},
+				Actions: []planner.Action{{
+					Op:     planner.OpDelete,
+					Object: planner.ObjectRef{Kind: "Secret", Name: "orphan", Namespace: "default"},
+				}},
+				RequiresApproval: true,
+			},
+			org:            &OrgPolicy{MaxRisk: "medium", AllowNamespaces: []string{"*"}},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "max_risk",
+		},
+		{
+			id: "SEC002-EVAL-009-helm-wipe-shape",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindInstall},
+				Actions: []planner.Action{{
+					Backend: "helm",
+					Command: []string{"helm", "uninstall", "redis", "--all"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "Helm uninstall",
+		},
+		{
+			id: "SEC002-EVAL-010-argo-wipe-shape",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindWorkflow},
+				Actions: []planner.Action{{
+					Backend: "argo",
+					Op:      planner.OpUpdate,
+					Object:  planner.ObjectRef{Kind: "Workflow", Name: "all", Namespace: "argo"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "unsupported Argo action",
+		},
+		{
+			id: "SEC002-EVAL-011-crossplane-wipe-shape",
+			plan: planner.ExecutionPlan{
+				Intent: intent.Intent{Kind: intent.KindCrossplane},
+				Actions: []planner.Action{{
+					Backend: "crossplane",
+					Op:      planner.OpUpdate,
+					Object:  planner.ObjectRef{Kind: "CompositeResourceClaim", Name: "all", Namespace: "default"},
+				}},
+			},
+			wantDenied:     true,
+			wantRisk:       RiskDenied,
+			wantMsgContain: "unsupported Crossplane action",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.id, func(t *testing.T) {
+			got := EvaluatePlanWithOrg(tc.plan, tc.org, "")
+			if got.Denied != tc.wantDenied {
+				t.Fatalf("denied=%v want %v result=%+v", got.Denied, tc.wantDenied, got)
+			}
+			if got.Risk != tc.wantRisk {
+				t.Fatalf("risk=%s want %s result=%+v", got.Risk, tc.wantRisk, got)
+			}
+			if tc.wantMsgContain != "" && !strings.Contains(got.Message, tc.wantMsgContain) {
+				t.Fatalf("message %q does not contain %q", got.Message, tc.wantMsgContain)
+			}
+			if len(tc.promptMissRefs) > 0 {
+				for _, ref := range tc.promptMissRefs {
+					if strings.TrimSpace(ref) == "" {
+						t.Fatalf("empty prompt miss ref in %s", tc.id)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add SEC-002 adversarial table-driven coverage for stubbed dangerous plans in EvaluatePlanWithOrg
- add pipeline test hook to inject stubbed planner output and verify denied plans never apply
- add executor defense-in-depth test for unknown delete kind rejection

## Notes
- links prompt-layer misses from SEC-001 to plan-layer catches
- updates include task tracker progress in kprompt-architecture repo