### PR TITLE
feat(cleanup): detect unused PVCs and Services with no endpoints

### DIFF
--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -21,6 +21,8 @@ Nothing applies silently, and `-o json` stays report-only.
 |------|----------------|-----------|
 | `Cleanup.UnusedConfigMap` | ConfigMap not referenced by any Pod, workload template, or ServiceAccount | Guidance, or approve-gated delete when orphans are confirmed |
 | `Cleanup.UnusedSecret` | Secret not referenced by env/envFrom/volumes/imagePullSecrets/ServiceAccount | Guidance, or approve-gated delete when orphans are confirmed |
+| `Cleanup.UnusedPVC` | PersistentVolumeClaim is not in the Bound phase | Guidance-only |
+| `Cleanup.EmptyService` | Service has a selector but zero active Endpoint addresses | Guidance-only |
 | `Cleanup.CompletedJob` | Job finished more than 24h ago (no `ttlSecondsAfterFinished`) | Approve-gated delete |
 | `Cleanup.OldReplicaSet` | Deployment-owned ReplicaSet scaled to zero (superseded revision) | Approve-gated delete |
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -71,15 +71,17 @@ func (a *Analyzer) Run(ctx context.Context, req Request) (incident.Investigation
 	orphans += a.scanSecrets(ctx, ns, refs, &out)
 	jobs := a.scanJobs(ctx, ns, now, jobAge, &out)
 	rss := a.scanReplicaSets(ctx, ns, &out)
+	pvcs := a.scanPVCs(ctx, ns, &out)
+	services := a.scanServices(ctx, ns, &out)
 
-	total := orphans + jobs + rss
+	total := orphans + jobs + rss + pvcs + services
 	scope := "cluster-wide"
 	if ns != "" {
 		scope = "namespace " + ns
 	}
 	out.Summary = fmt.Sprintf(
-		"%d cleanup candidate(s) in %s: %d unused ConfigMap/Secret(s), %d completed Job(s), %d superseded ReplicaSet(s)",
-		total, scope, orphans, jobs, rss,
+		"%d cleanup candidate(s) in %s: %d unused ConfigMap/Secret(s), %d completed Job(s), %d superseded ReplicaSet(s), %d unused PVC(s), %d empty Service(s)",
+		total, scope, orphans, jobs, rss, pvcs, services,
 	)
 	if total == 0 {
 		out.Summary += "; nothing to clean up"
@@ -373,6 +375,70 @@ func isSystemSecret(sec *corev1.Secret) bool {
 		return true
 	}
 	return false
+}
+
+func (a *Analyzer) scanPVCs(ctx context.Context, ns string, out *incident.Investigation) int {
+	list, err := a.Client.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{Limit: cluster.DefaultReadLimit})
+	if err != nil {
+		out.Degraded = appendUnique(out.Degraded, "persistentvolumeclaims")
+		return 0
+	}
+	count := 0
+	for i := range list.Items {
+		pvc := &list.Items[i]
+		if pvc.Status.Phase == corev1.ClaimBound {
+			continue
+		}
+		count++
+		addFinding(out, "Cleanup.UnusedPVC", incident.SeverityLow,
+			fmt.Sprintf("PersistentVolumeClaim/%s appears unused", pvc.Name),
+			fmt.Sprintf("PersistentVolumeClaim status phase is %q (not Bound)", pvc.Status.Phase),
+			"PersistentVolumeClaim", pvc.Name, pvc.Namespace, "Unused")
+	}
+	return count
+}
+
+func (a *Analyzer) scanServices(ctx context.Context, ns string, out *incident.Investigation) int {
+	list, err := a.Client.CoreV1().Services(ns).List(ctx, metav1.ListOptions{Limit: cluster.DefaultReadLimit})
+	if err != nil {
+		out.Degraded = appendUnique(out.Degraded, "services")
+		return 0
+	}
+	count := 0
+	for i := range list.Items {
+		svc := &list.Items[i]
+		if svc.Spec.ClusterIP == corev1.ClusterIPNone {
+			continue
+		}
+		if len(svc.Spec.Selector) == 0 {
+			continue
+		}
+		eps, err := a.Client.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// No endpoints object
+			} else {
+				continue // Skip if we get transient / forbidden errors
+			}
+		} else {
+			hasAddresses := false
+			for _, subset := range eps.Subsets {
+				if len(subset.Addresses) > 0 {
+					hasAddresses = true
+					break
+				}
+			}
+			if hasAddresses {
+				continue
+			}
+		}
+		count++
+		addFinding(out, "Cleanup.EmptyService", incident.SeverityLow,
+			fmt.Sprintf("Service/%s has no active endpoints", svc.Name),
+			fmt.Sprintf("Service has a selector but matches zero active pods in namespace %s", svc.Namespace),
+			"Service", svc.Name, svc.Namespace, "EmptyService")
+	}
+	return count
 }
 
 func roundDuration(d time.Duration) time.Duration {

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -77,6 +77,40 @@ func TestCleanupFindsUnusedAndStale(t *testing.T) {
 			},
 			Spec: appsv1.ReplicaSetSpec{Replicas: &zero},
 		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-orphan", Namespace: "payments"},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-bound", Namespace: "payments"},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty-service", Namespace: "payments"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.1", Selector: map[string]string{"app": "nonexistent"}},
+		},
+		&corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty-service", Namespace: "payments"},
+			Subsets:    []corev1.EndpointSubset{},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "used-service", Namespace: "payments"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.2", Selector: map[string]string{"app": "api"}},
+		},
+		&corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{Name: "used-service", Namespace: "payments"},
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "10.244.0.5"}},
+			}},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "headless-service", Namespace: "payments"},
+			Spec:       corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone, Selector: map[string]string{"app": "api"}},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-selector-service", Namespace: "payments"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.3"},
+		},
 	)
 
 	got, err := (&Analyzer{Client: client}).Run(context.Background(), Request{
@@ -91,6 +125,8 @@ func TestCleanupFindsUnusedAndStale(t *testing.T) {
 	requireFinding(t, got, "Cleanup.UnusedSecret", "orphan-secret")
 	requireFinding(t, got, "Cleanup.CompletedJob", "old-migrate")
 	requireFinding(t, got, "Cleanup.OldReplicaSet", "api-old")
+	requireFinding(t, got, "Cleanup.UnusedPVC", "pvc-orphan")
+	requireFinding(t, got, "Cleanup.EmptyService", "empty-service")
 
 	if hasFinding(got, "Cleanup.UnusedConfigMap", "app-config") {
 		t.Fatal("used configmap flagged")
@@ -107,7 +143,19 @@ func TestCleanupFindsUnusedAndStale(t *testing.T) {
 	if hasFinding(got, "Cleanup.CompletedJob", "recent-migrate") {
 		t.Fatal("recent job flagged")
 	}
-	if !strings.Contains(got.Summary, "4 cleanup candidate(s)") {
+	if hasFinding(got, "Cleanup.UnusedPVC", "pvc-bound") {
+		t.Fatal("bound PVC flagged")
+	}
+	if hasFinding(got, "Cleanup.EmptyService", "used-service") {
+		t.Fatal("used service flagged")
+	}
+	if hasFinding(got, "Cleanup.EmptyService", "headless-service") {
+		t.Fatal("headless service flagged")
+	}
+	if hasFinding(got, "Cleanup.EmptyService", "no-selector-service") {
+		t.Fatal("no selector service flagged")
+	}
+	if !strings.Contains(got.Summary, "6 cleanup candidate(s)") {
 		t.Fatalf("summary=%q", got.Summary)
 	}
 }

--- a/internal/suggest/cleanup.go
+++ b/internal/suggest/cleanup.go
@@ -88,6 +88,11 @@ func FromCleanup(_ context.Context, inv incident.Investigation, prompt string) (
 				},
 				Diff: fmt.Sprintf("- ReplicaSet/%s -n %s (superseded, 0 replicas)", ref.Name, ref.Namespace),
 			})
+		case "Cleanup.UnusedPVC", "Cleanup.EmptyService":
+			addAuditGuidance(&guidance, seenGuidance, f.Code,
+				cleanupGuidanceTitle(f.Code),
+				fmt.Sprintf("describe %s/%s", strings.ToLower(ref.Kind), ref.Name),
+				cleanupGuidanceSummary(f.Code))
 		case "Cleanup.UnusedConfigMap", "Cleanup.UnusedSecret":
 			if !confirmOrphans {
 				addAuditGuidance(&guidance, seenGuidance, f.Code,
@@ -195,6 +200,10 @@ func cleanupGuidanceTitle(code string) string {
 		return "Review unused ConfigMap"
 	case "Cleanup.UnusedSecret":
 		return "Review unused Secret"
+	case "Cleanup.UnusedPVC":
+		return "Review unused PVC"
+	case "Cleanup.EmptyService":
+		return "Review empty Service"
 	default:
 		return "Review cleanup candidate"
 	}
@@ -206,6 +215,10 @@ func cleanupGuidanceSummary(code string) string {
 		return "ConfigMaps stay guidance-only unless you confirm orphans (e.g. \"cleanup … and confirm orphans\"); CRD/GitOps refs may be unscanned"
 	case "Cleanup.UnusedSecret":
 		return "Secrets stay guidance-only unless you confirm orphans; false positives are common — confirm then delete"
+	case "Cleanup.UnusedPVC":
+		return "PersistentVolumeClaim is not Bound; verify if it is needed or if storage provisioning failed"
+	case "Cleanup.EmptyService":
+		return "Service has a selector but zero active endpoints; traffic to this service will fail"
 	default:
 		return "Review the finding before deleting"
 	}

--- a/internal/suggest/cleanup_test.go
+++ b/internal/suggest/cleanup_test.go
@@ -17,6 +17,8 @@ func TestFromCleanupDeletesJobsAndReplicaSets(t *testing.T) {
 			auditFinding("Cleanup.OldReplicaSet", "ReplicaSet/api-old has 0 replicas", "ReplicaSet", "api-old", "payments"),
 			auditFinding("Cleanup.UnusedConfigMap", "ConfigMap/orphan-config appears unused", "ConfigMap", "orphan-config", "payments"),
 			auditFinding("Cleanup.UnusedSecret", "Secret/orphan-secret appears unused", "Secret", "orphan-secret", "payments"),
+			auditFinding("Cleanup.UnusedPVC", "PersistentVolumeClaim/pvc-orphan appears unused", "PersistentVolumeClaim", "pvc-orphan", "payments"),
+			auditFinding("Cleanup.EmptyService", "Service/empty-service has no active endpoints", "Service", "empty-service", "payments"),
 		},
 	}
 	suggestions, err := FromCleanup(context.Background(), inv, "cleanup payments namespace")
@@ -41,15 +43,31 @@ func TestFromCleanupDeletesJobsAndReplicaSets(t *testing.T) {
 			t.Fatalf("unexpected kind %s", a.Object.Kind)
 		}
 	}
-	if len(suggestions) < 3 {
-		t.Fatalf("expected guidance for ConfigMap/Secret: %+v", suggestions)
+	if len(suggestions) < 5 {
+		t.Fatalf("expected guidance for ConfigMap/Secret/PVC/Service: %+v", suggestions)
 	}
+	var sawPVC, sawService bool
 	for _, s := range suggestions {
-		if s.Code == "Cleanup.UnusedConfigMap" || s.Code == "Cleanup.UnusedSecret" {
+		if s.Code == "Cleanup.UnusedConfigMap" || s.Code == "Cleanup.UnusedSecret" || s.Code == "Cleanup.UnusedPVC" || s.Code == "Cleanup.EmptyService" {
 			if s.Plan != nil {
 				t.Fatalf("%s must be guidance-only", s.Code)
 			}
+			if s.Code == "Cleanup.UnusedPVC" {
+				sawPVC = true
+				if s.Title != "Review unused PVC" {
+					t.Fatalf("unexpected title for PVC: %s", s.Title)
+				}
+			}
+			if s.Code == "Cleanup.EmptyService" {
+				sawService = true
+				if s.Title != "Review empty Service" {
+					t.Fatalf("unexpected title for Service: %s", s.Title)
+				}
+			}
 		}
+	}
+	if !sawPVC || !sawService {
+		t.Fatal("expected PVC and Service guidance suggestions")
 	}
 }
 


### PR DESCRIPTION
## Summary

Expands the SRE `cleanup` tool with two new hygiene checks to identify unused resources:
1. **Unused PVCs (`Cleanup.UnusedPVC`):** Flags PersistentVolumeClaims that are not in the `Bound` phase (e.g. `Pending`). Bound PVCs are skipped for safety to avoid potential storage data loss.
2. **Empty Services (`Cleanup.EmptyService`):** Flags selector-configured Services that match zero active/ready Pods (zero active Endpoint addresses). Headless and no-selector Services are explicitly ignored.

Both checks map to guidance-only suggestions in the `suggest` path.

Fixes 
- #79

## Changes

- **`internal/cleanup/cleanup.go`**: Added `scanPVCs` and `scanServices` to scan, verify phase/endpoints, and add findings.
- **`internal/cleanup/cleanup_test.go`**: Added test cases for PVC and Service states (Bound, Pending, empty Endpoints, active Endpoints, headless, and no-selector).
- **`internal/suggest/cleanup.go`**: Mapped the new finding codes to custom guidance suggestions.
- **`internal/suggest/cleanup_test.go`**: Verified guidance-only suggestion mapping.
- **`docs/cleanup.md`**: Documented the new codes and expected outcomes.

## Test plan

- [x] All unit tests pass cleanly: `go test ./...`
- [x] Verified summaries and finding outputs under simulated cluster states.

## AI Usage
- **Use:** yes
- **Model:** Gemini 1.5 Pro
- **Used for:** Implementing the unbound PVC and empty selector Service scanning logic, writing unit tests and drafting PR description.