### PR TITLE
SEC-004: secret non-leak matrix coverage

### DIFF
--- a/internal/config/perms_test.go
+++ b/internal/config/perms_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveFileUses0600AndRedactsSecrets(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("KPROMPT_HOME", filepath.Join(dir, ".kprompt"))
+
+	if err := SaveFile(File{
+		Provider: "openai",
+		Model:    "gpt-4o-mini",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := DefaultPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config perms = %04o, want 0600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if strings.Contains(strings.ToLower(body), "api_key") || strings.Contains(body, "sk-") {
+		t.Fatalf("secret leaked into config file:\n%s", body)
+	}
+}

--- a/internal/doctor/redaction_test.go
+++ b/internal/doctor/redaction_test.go
@@ -1,0 +1,65 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kprompt/kprompt/internal/config"
+	"github.com/kprompt/kprompt/internal/team"
+	"github.com/kprompt/kprompt/internal/tools"
+)
+
+func TestRunRedactsPulledSecretValues(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("KPROMPT_HOME", filepath.Join(dir, ".kprompt"))
+	t.Setenv("KPROMPT_OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	config.ResetPulledSecretsCache()
+	t.Cleanup(config.ResetPulledSecretsCache)
+
+	if _, err := config.SetField("provider", "openai"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".kprompt", "provider-secrets.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("openai: sk-from-pull\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config.ResetPulledSecretsCache()
+
+	rep, err := Run(context.Background(), Options{
+		Detect: func(context.Context, tools.DetectOptions) (*tools.Registry, error) {
+			return tools.NewRegistry([]tools.Result{
+				{ID: tools.IDKubernetes, Name: "Kubernetes", Status: tools.StatusAvailable, Detail: "ok"},
+			}), nil
+		},
+		Me: func(context.Context, string, string) (team.MeResponse, error) {
+			t.Fatal("me should not be called")
+			return team.MeResponse{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := FormatText(&buf, rep); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "sk-from-pull") {
+		t.Fatalf("secret leaked into doctor output:\n%s", out)
+	}
+	if !strings.Contains(out, "provider key(s) cached") {
+		t.Fatalf("expected cached secret summary, got:\n%s", out)
+	}
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -75,14 +75,14 @@ func TestFromPlanOmitsManifest(t *testing.T) {
 		Actions: []planner.Action{{
 			Op:       planner.OpCreate,
 			Object:   planner.ObjectRef{Kind: "Deployment", Name: "redis", Namespace: "demo"},
-			Manifest: "apiVersion: apps/v1\nsecret: SHOULD_NOT_APPEAR\n",
+			Manifest: "apiVersion: v1\nkind: Secret\ndata:\n  token: hunter2\n",
 		}},
 	}, safety.Result{Risk: safety.RiskMedium}, true)
 	raw, err := json.Marshal(e)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(raw), "SHOULD_NOT_APPEAR") || strings.Contains(string(raw), "apiVersion") {
+	if strings.Contains(string(raw), "hunter2") || strings.Contains(strings.ToLower(string(raw)), "token") {
 		t.Fatalf("leaked manifest: %s", raw)
 	}
 	if len(e.Actions) != 1 || e.Actions[0] != "create Deployment/redis -n demo" {

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -20,7 +20,7 @@ func TestFromPlanSchema(t *testing.T) {
 			Object:   planner.ObjectRef{Kind: "Deployment", Name: "api", Namespace: "demo"},
 			Replicas: &rep,
 			Diff:     "replicas: 1 → 3",
-			Manifest: "SECRET",
+			Manifest: "apiVersion: v1\nkind: Secret\ndata:\n  password: hunter2\n",
 		}},
 		Summary:          "Scale api",
 		RequiresApproval: true,
@@ -33,7 +33,7 @@ func TestFromPlanSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(raw), "SECRET") {
+	if strings.Contains(string(raw), "hunter2") || strings.Contains(strings.ToLower(string(raw)), "password") {
 		t.Fatal("manifest leaked")
 	}
 	var buf bytes.Buffer

--- a/internal/team/perms_test.go
+++ b/internal/team/perms_test.go
@@ -1,0 +1,56 @@
+package team
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveCredentialsUses0600(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("KPROMPT_HOME", filepath.Join(dir, ".kprompt"))
+
+	if err := SaveCredentials(Credentials{
+		APIURL:   "https://api.kprompt.ai",
+		APIToken: "team-token-123",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := CredentialsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credentials perms = %04o, want 0600", got)
+	}
+}
+
+func TestSaveProviderSecretsUses0600(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("KPROMPT_HOME", filepath.Join(dir, ".kprompt"))
+
+	if err := SaveProviderSecrets(map[string]string{
+		"openai": "sk-from-pull",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := ProviderSecretsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("provider secrets perms = %04o, want 0600", got)
+	}
+}


### PR DESCRIPTION
SEC-004 adds adversarial coverage for secret / credential non-leak behavior.

## Changes

- Adds 0600 permission tests for config, credentials, and pulled provider secrets
- Adds doctor redaction coverage for pulled provider keys
- Tightens history/output tests to ensure secret-like manifest material does not leak
- Preserves agent watch and Discord non-leak behavior

## Testing

- go test ./internal/config ./internal/team ./internal/history ./internal/output ./internal/doctor ./internal/agent/watch ./internal/agent/notify/discord

## Acceptance

- [x] Matrix covered by automated tests
- [x] Config write paths enforce 0600 for credential/secret files
- [x] Doctor / brief output redacts or omits key material
- [x] No change to the Secret read RBAC product rule
- [x] go test green

Related issue: #228