### PR TITLE
feat(wait): extend --wait beyond Deployments to support StatefulSets (#77)

### DIFF
--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -107,7 +107,7 @@ Bare kprompt (no args) prints a readiness coach. Full help: kprompt --help · kp
 
 	root.PersistentFlags().BoolVar(&approve, "approve", false, "apply the plan without interactive confirmation")
 	root.PersistentFlags().BoolVar(&approveEachContext, "approve-each-context", false, "apply a mutating plan to every --contexts entry (explicit; not implied by --approve)")
-	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment rollout to complete")
+	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment/StatefulSet rollout to complete")
 	root.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for --wait (default 5m)")
 	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|openrouter|together|ollama|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")

--- a/internal/cluster/wait_test.go
+++ b/internal/cluster/wait_test.go
@@ -75,3 +75,67 @@ func TestDeploymentComplete(t *testing.T) {
 		t.Fatal("expected incomplete")
 	}
 }
+
+func TestWaitStatefulSetAlreadyReady(t *testing.T) {
+	replicas := int32(2)
+	client := fake.NewSimpleClientset(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: "default", Generation: 1},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &replicas},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           2,
+			UpdatedReplicas:    2,
+			ReadyReplicas:      2,
+		},
+	})
+	var out bytes.Buffer
+	err := (&Waiter{Client: client, Out: &out}).WaitStatefulSet(context.Background(), "default", "redis", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "ready") {
+		t.Fatalf("output=%q", out.String())
+	}
+}
+
+func TestWaitStatefulSetTimeout(t *testing.T) {
+	replicas := int32(2)
+	client := fake.NewSimpleClientset(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: "default", Generation: 2},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &replicas},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			ReadyReplicas:      1,
+		},
+	})
+	err := (&Waiter{Client: client}).WaitStatefulSet(context.Background(), "default", "redis", 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for StatefulSet/redis") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestStatefulSetComplete(t *testing.T) {
+	replicas := int32(1)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 3},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &replicas},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 3,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			ReadyReplicas:      1,
+		},
+	}
+	if !statefulSetRolledOut(sts) {
+		t.Fatal("expected complete")
+	}
+	sts.Status.ReadyReplicas = 0
+	if statefulSetRolledOut(sts) {
+		t.Fatal("expected incomplete")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1354,7 +1354,7 @@ func RunWith(ctx context.Context, cfg config.Resolved, out io.Writer, deps Deps)
 			case "StatefulSet":
 				err = waiter.WaitStatefulSet(ctx, t.Namespace, t.Name, timeout)
 			default:
-				fmt.Fprintln(out, "Skipping --wait for unsupported resource kind %s", t.Kind)
+				fmt.Fprintf(out, "Skipping --wait for unsupported resource kind %s\n", t.Kind)
 				continue
 			}
 			if err != nil {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -64,10 +64,10 @@ type Deps struct {
 	Prometheus    toolprometheus.Querier
 	OTel          toolotel.Querier
 	Grafana       toolgrafana.Querier
-	Confirm       ConfirmFunc             // if set, used instead of TTY prompt
-	IsTerminal    *bool                   // override ui.StdinIsTerminal when non-nil
-	OnResult      func(output.PlanResult) // optional per-plan completion observer
-	SkipOrgPolicy bool                    // tests: ignore Team org policy (Free CLI path)
+	Confirm       ConfirmFunc                                        // if set, used instead of TTY prompt
+	IsTerminal    *bool                                              // override ui.StdinIsTerminal when non-nil
+	OnResult      func(output.PlanResult)                            // optional per-plan completion observer
+	SkipOrgPolicy bool                                               // tests: ignore Team org policy (Free CLI path)
 	BuildPlan     func(intent.Intent) (planner.ExecutionPlan, error) // tests: override planner.Build
 	// RouteSteps forces a multi-step route (recipe run / tests). When set, skips
 	// SplitRoutePrompt / recipe.TryRoute matching on cfg.Prompt.
@@ -1349,10 +1349,13 @@ func RunWith(ctx context.Context, cfg config.Resolved, out io.Writer, deps Deps)
 		for _, t := range targets {
 			var err error
 			switch t.Kind {
+			case "Deployment":
+				err = waiter.WaitDeployment(ctx, t.Namespace, t.Name, timeout)
 			case "StatefulSet":
 				err = waiter.WaitStatefulSet(ctx, t.Namespace, t.Name, timeout)
 			default:
-				err = waiter.WaitDeployment(ctx, t.Namespace, t.Name, timeout)
+				fmt.Fprintln(out, "Skipping --wait for unsupported resource kind %s", t.Kind)
+				continue
 			}
 			if err != nil {
 				rep := verify.Report{


### PR DESCRIPTION
## Summary

Fixes #77

With the core `WaitStatefulSet` engine landed in #76, this PR completes the remaining acceptance criteria for issue #77 by updating CLI flag documentation, adding targeted unit tests, and ensuring unsupported kinds are handled gracefully.

## Changes

- **CLI Help Text (`cmd/kprompt/main.go`):** Updated `--wait` flag description to explicitly mention Deployment and StatefulSet support.
- **Unsupported Kinds Handling:** Ensured `--wait` skips unsupported resource kinds with a clear message instead of silently failing or faking success.
- **Unit Tests (`internal/cluster/wait_test.go`):** Added comprehensive unit tests for `WaitStatefulSet` covering ready rollout states, pending timeout cases, and completion helper assertions.

## Test plan

- [x] `go test ./...` (CLI) and/or website checks as applicable
- [ ] Manual: relevant `kprompt "..."` prompts / install path verified
- [x] No secrets, kubeconfigs, or API keys in the diff