### PR TITLE
fix(planner): reject unsupported scale kinds early (DaemonSet etc.)

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -482,6 +482,15 @@ func buildScale(in intent.Intent, ns string) (ExecutionPlan, error) {
 	if in.Target.Kind != "" {
 		kind = cluster.NormalizeKind(in.Target.Kind)
 	}
+	
+	// Gatekeeper: only allow supported scale kinds
+	switch kind {
+	case "Deployment", "StatefulSet":
+		// OK
+	default:
+		return ExecutionPlan{}, fmt.Errorf("scale kind %q not supported (Deployment, StatefulSet only)", kind)
+	}
+
 	rep := replicas
 	return ExecutionPlan{
 		Intent: in,

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -104,6 +104,38 @@ func TestBuildScaleStatefulSet(t *testing.T) {
 	}
 }
 
+func TestBuildScaleRejectsUnsupportedKinds(t *testing.T) {
+	cases := []struct {
+		name string
+		kind string
+	}{
+		{"daemonset", "DaemonSet"},
+		{"job", "Job"},
+		{"cronjob", "CronJob"},
+		{"pod", "Pod"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Build(intent.Intent{
+				Kind: intent.KindScale,
+				Target: intent.Target{
+					Kind:      tc.kind,
+					Name:      "test-target",
+					Namespace: "demo",
+				},
+				Params: map[string]any{"replicas": float64(3)},
+			})
+			if err == nil {
+				t.Fatalf("expected error when scaling unsupported kind %s, got nil", tc.kind)
+			}
+			if !strings.Contains(err.Error(), "not supported") {
+				t.Fatalf("expected 'not supported' error message, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestBuildGetPods(t *testing.T) {
 	in := intent.Intent{
 		Kind: intent.KindGet,


### PR DESCRIPTION
Closes #112 

### Why
`buildScale` was blindly accepting any `Target.Kind`, passing unsupported types (like `DaemonSet` or `Job`) down to the executor. This resulted in a late-stage failure after the user had already approved the execution plan.

### Acceptance Criteria Met
* Added a strict allowlist `switch` block in `buildScale` that rejects any kind other than `Deployment` and `StatefulSet`.
* Returns an immediate, clear error to the user naming the allowlist.
* Added `TestBuildScaleRejectsUnsupportedKinds` unit test coverage in `planner_test.go` to enforce the allowlist logic and verify error messages.