### PR TITLE
build(compat): restore Go 1.23 compatibility in autopilot tests

### DIFF
--- a/internal/agent/autopilot/outcome_test.go
+++ b/internal/agent/autopilot/outcome_test.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -75,7 +76,7 @@ func TestAttachVerifyFailedClearsApplied(t *testing.T) {
 		Plan:       PlanBody{Summary: "rollback"},
 	}
 	// nil client → verify skipped (not failed). Use skipped path.
-	rep := AttachVerify(t.Context(), nil, prop)
+	rep := AttachVerify(context.Background(), nil, prop)
 	if rep.Status != verify.Skipped {
 		t.Fatalf("nil client should skip: %+v", rep)
 	}


### PR DESCRIPTION
## Summary
Restores build and test compatibility with Go 1.23 by replacing the Go 1.24+ test context method with standard context primitives.

Fixes 
- #122

## Key Changes
* **Fix build regression:** Replaced `t.Context()` with `context.Background()` in `internal/agent/autopilot/outcome_test.go` and added the standard `"context"` package import.

## Test Results
Verified `go test ./internal/agent/autopilot/...` compiles and runs successfully on Go 1.23.