### PR TITLE
ci: skip SonarCloud scan on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
         run: go build -o bin/kprompt ./cmd/kprompt
       # Requires Automatic Analysis disabled on SonarCloud (Project → Administration → Analysis Method).
       # CI-based analysis cannot run while Autoscan is enabled.
+      # Skipped for forks and Dependabot PRs: GitHub does not expose SONAR_TOKEN
+      # to those runs, so the scan would fail on a missing token.
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838 # v3.1.0
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- All 10 open Dependabot PRs (#125–#134) currently show a failing `test` check.
- Root cause is **not** the dependency bumps: the `SonarCloud Scan` step fails with `Set the SONAR_TOKEN env variable.` because GitHub does not expose repository secrets to Dependabot-triggered workflow runs.
- The existing `if` guard only skipped the scan for forked PRs. This extends it to also skip when `github.actor == 'dependabot[bot]'`, unblocking the `test` check on all Dependabot PRs.

## Test plan
- [ ] Confirm `test` passes on this PR (non-Dependabot, so SonarCloud still runs).
- [ ] Re-run CI on one Dependabot PR (e.g. #125) and confirm the SonarCloud step is skipped and `test` goes green.

Made with [Cursor](https://cursor.com)