### PR TITLE
ci: bump Go to 1.25.x to match go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0  # SonarCloud needs full history for blame and new-code analysis
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.23.x"
+          go-version: "1.25.x"
       - name: Test with coverage
         run: go test -json -coverprofile=coverage.out -covermode=atomic ./... > report.json || true
       - name: Build


### PR DESCRIPTION
## Summary
- `go.mod` now requires `go 1.25.0` (raised transitively by recent dependency bumps), but CI pinned `go-version: 1.23.x`.
- The `test` job only passed because setup-go v5 auto-downloaded the 1.25 toolchain. setup-go v7 (#133) sets `GOTOOLCHAIN=local`, which surfaced the mismatch as a build failure: `go.mod requires go >= 1.25.0 (running go 1.23.12)`.
- Pin CI to `1.25.x` to align with `go.mod` and remove reliance on implicit toolchain downloads.

## Test plan
- [ ] `test` check passes on this PR with Go 1.25.x.
- [ ] After merge, rebase #133 (setup-go v7) and confirm it goes green.

Made with [Cursor](https://cursor.com)