### PR TITLE
ci: derive Go version from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0  # SonarCloud needs full history for blame and new-code analysis
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
       - name: Test with coverage
         run: go test -json -coverprofile=coverage.out -covermode=atomic ./... > report.json || true
       - name: Build


### PR DESCRIPTION
## Summary
- Pinned `go-version` kept going stale as dependency bumps raised the `go` directive in `go.mod` (1.23 -> 1.25 -> 1.26), repeatedly breaking the `test` build under setup-go's `GOTOOLCHAIN=local`.
- Switch to `go-version-file: go.mod` so CI always uses the Go version the module actually requires. Future go.mod bumps need no CI change, and setup-go v7 (#133) will pass.

## Test plan
- [ ] `test` passes on this PR using the Go version from go.mod (1.26.x).
- [ ] After merge, rebase #133 (setup-go v7) and confirm green.

Made with [Cursor](https://cursor.com)