### PR TITLE
docs: add cobra examples for team / utility commands (#107)

### DIFF
--- a/cmd/kprompt/config.go
+++ b/cmd/kprompt/config.go
@@ -26,7 +26,9 @@ func newConfigCmd() *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value (provider|model|base_url|context|namespace|require_alias_match|tools.*|gitops.*)",
-		Args:  cobra.ExactArgs(2),
+		Example: `  kprompt config set provider anthropic
+  kprompt config set model gpt-5`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			f, err := config.SetField(args[0], args[1])
 			if err != nil {
@@ -68,6 +70,8 @@ func newConfigAliasCmd() *cobra.Command {
 		Use:   "set <name> <kube-context>",
 		Short: "Map an alias to a kubeconfig context",
 		Args:  cobra.ExactArgs(2),
+		Example: `  kprompt config alias set prod gke_myproj_us-central1_prod
+  kprompt config alias set staging kind-staging`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			f, err := config.SetAlias(args[0], args[1])
 			if err != nil {
@@ -82,7 +86,9 @@ func newConfigAliasCmd() *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "unset <name>",
 		Short: "Remove a context alias",
-		Args:  cobra.ExactArgs(1),
+		Example: `kprompt config alias unset prod
+  kprompt config alias unset staging`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := config.UnsetAlias(args[0]); err != nil {
 				return err

--- a/cmd/kprompt/contexts.go
+++ b/cmd/kprompt/contexts.go
@@ -17,7 +17,8 @@ func newContextsCmd() *cobra.Command {
 		Short:   "List kubeconfig contexts and local aliases",
 		Long:    "Shows kubeconfig contexts, which are current, and aliases from ~/.kprompt/config.yaml. Optional --check probes API reachability per context.",
 		Example: `  kprompt contexts
-  kprompt contexts --check`,
+  kprompt contexts --check
+  kprompt contexts --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rep, err := contexts.List(cmd.Context(), contexts.Options{
 				CheckReachability: check,

--- a/cmd/kprompt/dash.go
+++ b/cmd/kprompt/dash.go
@@ -20,6 +20,17 @@ func newDashCmd() *cobra.Command {
 		Use:   "dash",
 		Short: "Open the local read-only cluster dashboard",
 		Long:  "Starts kprompt-dash on localhost (kubeconfig stays on this machine). Install: go install github.com/kprompt/kprompt-dash/cmd/kprompt-dash@latest",
+		Example: `  # Basic launch
+  kprompt dash
+  
+  # Disable automatic open behavior
+  kprompt dash --open=false
+
+  # Different address / port
+  kprompt dash --addr 127.0.0.1:8080
+
+  # Target a specific kubeconfig context
+  kprompt dash --context staging`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bin, err := lookDashBinary()
 			if err != nil {

--- a/cmd/kprompt/doctor.go
+++ b/cmd/kprompt/doctor.go
@@ -18,7 +18,8 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Check local setup (kube, LLM key, tools, Team)",
 		Long:  "Runs read-only health checks. Does not print API keys. Exit code 1 if a required check fails.",
 		Example: `  kprompt doctor
-  kprompt doctor --json`,
+  kprompt doctor --json
+  kprompt doctor --context staging`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rep, err := doctor.Run(cmd.Context(), doctor.Options{Context: kubeCtx})
 			if err != nil {

--- a/cmd/kprompt/login.go
+++ b/cmd/kprompt/login.go
@@ -19,6 +19,8 @@ func newLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Enroll this CLI with a Team org (device login)",
 		Long:  "Starts a device-code flow against the control plane. Approve the user code at app.kprompt.ai/connect, then a kp_… token is stored in ~/.kprompt/credentials.yaml (0600).",
+		Example: `  kprompt login
+  kprompt login --open`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := strings.TrimSpace(apiURL)
 			if url == "" {
@@ -67,8 +69,9 @@ func newLoginCmd() *cobra.Command {
 
 func newLogoutCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "logout",
-		Short: "Revoke the local Team API token and clear credentials",
+		Use:     "logout",
+		Short:   "Revoke the local Team API token and clear credentials",
+		Example: `  kprompt logout`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			creds, _, err := team.LoadCredentials()
 			if err != nil {
@@ -94,8 +97,9 @@ func newLogoutCmd() *cobra.Command {
 
 func newWhoamiCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "whoami",
-		Short: "Show Team enrollment status",
+		Use:     "whoami",
+		Short:   "Show Team enrollment status",
+		Example: `  kprompt whoami`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			creds, ok, err := team.LoadCredentials()
 			if err != nil {

--- a/cmd/kprompt/policy.go
+++ b/cmd/kprompt/policy.go
@@ -19,8 +19,9 @@ func newPolicyCmd() *cobra.Command {
 		},
 	}
 	cmd.AddCommand(&cobra.Command{
-		Use:   "pull",
-		Short: "Fetch org policy from the control plane and cache it",
+		Use:     "pull",
+		Short:   "Fetch org policy from the control plane and cache it",
+		Example: `  kprompt policy pull`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pol, err := team.PullPolicy(cmd.Context())
 			if err != nil {
@@ -32,8 +33,9 @@ func newPolicyCmd() *cobra.Command {
 		},
 	})
 	cmd.AddCommand(&cobra.Command{
-		Use:   "show",
-		Short: "Show the cached org policy",
+		Use:     "show",
+		Short:   "Show the cached org policy",
+		Example: `  kprompt policy show`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return showPolicy(cmd)
 		},

--- a/cmd/kprompt/run.go
+++ b/cmd/kprompt/run.go
@@ -38,6 +38,9 @@ POST /v1/runs/{id}/result.
 
 Requires kprompt login (operator or admin). Empty state in the app:
 "Enroll a CLI worker (kprompt login + kprompt run listen)".`,
+		Example: `  kprompt run listen
+  kprompt run listen --interval 5s
+  kprompt run listen --worker-label my-worker-123`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			creds, ok, err := team.LoadCredentials()
 			if err != nil {

--- a/cmd/kprompt/secrets.go
+++ b/cmd/kprompt/secrets.go
@@ -15,8 +15,9 @@ func newSecretsCmd() *cobra.Command {
 		Long:  "Caches keys at ~/.kprompt/provider-secrets.yaml (0600). Env vars always override pulled keys. Does not print secret values.",
 	}
 	cmd.AddCommand(&cobra.Command{
-		Use:   "pull",
-		Short: "Fetch org provider keys and cache them locally",
+		Use:     "pull",
+		Short:   "Fetch org provider keys and cache them locally",
+		Example: `  kprompt secrets pull`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			secrets, err := team.PullSecrets(cmd.Context())
 			if err != nil {


### PR DESCRIPTION
Fixes #107
- Added examples in with local flags and relevant args
- I didn't add any persistent flags from cmd/kprompt/main.go in examples, because I wasn't 100% sure if they were relevant or not. And the other examples didn't have them.
- Please let me know if you would like any changes made thanks.

## Test plan

- [x] `go test ./...` (CLI) and/or website checks as applicable
- [x] Manual: relevant `kprompt "..."` prompts / install path verified
- [x] No secrets, kubeconfigs, or API keys in the diff

