### PR TITLE
ci: derive Go version from go.mod in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.23.x"
+          go-version-file: go.mod
       # TODO: pin codeql-action to a commit SHA to match the repo's action-pinning policy.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary
- `codeql.yml` still pinned `go-version: 1.23.x`, but `go.mod` now requires `go 1.26.0` and the workflow uses setup-go v7 (`GOTOOLCHAIN=local`).
- This fails the `Analyze (go)` job repo-wide (main pushes and unrelated PRs such as #121), not because of any code in those PRs.
- Mirror the `ci.yml` fix: use `go-version-file: go.mod` so CodeQL builds with the Go version the module requires.

## Test plan
- [ ] `Analyze (go)` passes on this PR.
- [ ] Confirms green on main after merge, unblocking the check on #121.

Made with [Cursor](https://cursor.com)