### PR TITLE
ci: pass --trust to cursor-agent (fix headless no-output)

### DIFF
--- a/.github/workflows/cursor-comment.yml
+++ b/.github/workflows/cursor-comment.yml
@@ -101,7 +101,9 @@ jobs:
           markdown only.
           EOP
           )"
-          agent -p "$PROMPT" --output-format text --model gpt-5 < input.md > answer.md || true
+          # --trust suppresses the headless "Workspace Trust Required" prompt.
+          # No --force, so the agent only reads/writes stdout (never edits files).
+          agent -p "$PROMPT" --trust --output-format text --model gpt-5 < input.md > answer.md || true
           test -s answer.md || echo "_Cursor produced no output._" > answer.md
 
       - name: Post reply

--- a/.github/workflows/cursor-review.yml
+++ b/.github/workflows/cursor-review.yml
@@ -71,7 +71,9 @@ jobs:
           - Write "No blocking issues found." if nothing significant stands out.
           EOP
           )"
-          agent -p "$PROMPT" --output-format text --model gpt-5 < pr.diff > review.md || true
+          # --trust suppresses the headless "Workspace Trust Required" prompt.
+          # No --force, so the agent only reads/writes stdout (never edits files).
+          agent -p "$PROMPT" --trust --output-format text --model gpt-5 < pr.diff > review.md || true
           test -s review.md || echo "_Cursor review produced no output._" > review.md
 
       - name: Post review comment


### PR DESCRIPTION
## Summary
- The cursor-agent runs posted "_Cursor produced no output._" because the agent blocked on the interactive `⚠ Workspace Trust Required` prompt in CI.
- Fix: add the documented `--trust` flag (headless trust bypass) to the `agent` invocation in both `cursor-review.yml` and `cursor-comment.yml`.
- `--force` is intentionally omitted, so the agent remains read-only (stdin → stdout) and never edits files.

## Test plan
- [ ] After merge, comment `/cursor review` on an open PR and confirm a real review is posted.

Made with [Cursor](https://cursor.com)