### PR TITLE
ci: embed diff/context in cursor-agent prompt

### DIFF
--- a/.github/workflows/cursor-comment.yml
+++ b/.github/workflows/cursor-comment.yml
@@ -95,9 +95,9 @@ jobs:
         run: |
           PROMPT="$(cat <<'EOP'
           You are the kprompt project's GitHub assistant, responding to a maintainer's
-          request on an issue or pull request. The stdin contains, in order: the
-          maintainer's REQUEST, then the ITEM CONTEXT (title, body, and — for a PR — the
-          unified diff).
+          request on an issue or pull request. Below (after the marker) you are given,
+          in order: the maintainer's REQUEST, then the ITEM CONTEXT (title, body, and —
+          for a PR — the unified diff).
 
           - If it is a PR and the request is a review, review the diff for real bugs,
             security issues (secrets in code/logs, shell/exec injection, unsafe input),
@@ -109,9 +109,15 @@ jobs:
           markdown only.
           EOP
           )"
+          # cursor-agent -p does not read piped stdin, so embed the input in the prompt.
+          # Passed as a double-quoted shell var (no eval) -> safe from injection.
+          INPUT="$(cat input.md)"
           # --trust suppresses the headless "Workspace Trust Required" prompt.
           # No --force, so the agent only reads/writes stdout (never edits files).
-          agent -p "$PROMPT" --trust --output-format text --model auto < input.md > answer.md || true
+          agent -p "$PROMPT
+
+          --- BEGIN DATA ---
+          $INPUT" --trust --output-format text --model auto > answer.md || true
           test -s answer.md || echo "_Cursor produced no output._" > answer.md
 
       - name: Post reply

--- a/.github/workflows/cursor-review.yml
+++ b/.github/workflows/cursor-review.yml
@@ -59,7 +59,8 @@ jobs:
         run: |
           PROMPT="$(cat <<'EOP'
           You are a senior code reviewer for the kprompt project (a Go CLI + in-cluster
-          Kubernetes agent). Review ONLY the unified diff provided on stdin.
+          Kubernetes agent). Review ONLY the unified diff provided below (after the
+          "UNIFIED DIFF:" marker).
 
           Focus on high-signal issues:
           - Real bugs, nil derefs, error handling, concurrency/goroutine leaks.
@@ -79,9 +80,15 @@ jobs:
           - Write "No blocking issues found." if nothing significant stands out.
           EOP
           )"
+          # cursor-agent -p does not read piped stdin, so embed the diff in the prompt.
+          # Passed as a double-quoted shell var (no eval) -> safe from injection.
+          DIFF="$(cat pr.diff)"
           # --trust suppresses the headless "Workspace Trust Required" prompt.
           # No --force, so the agent only reads/writes stdout (never edits files).
-          agent -p "$PROMPT" --trust --output-format text --model auto < pr.diff > review.md || true
+          agent -p "$PROMPT
+
+          UNIFIED DIFF:
+          $DIFF" --trust --output-format text --model auto > review.md || true
           test -s review.md || echo "_Cursor review produced no output._" > review.md
 
       - name: Post review comment


### PR DESCRIPTION
## Summary
- `cursor-agent -p` ignores piped stdin, so the agent replied that no input was provided.
- Embed the content directly in the `-p` prompt: the PR diff (`cursor-review.yml`) and the request+context (`cursor-comment.yml`), via a double-quoted shell variable — no `eval`, so still safe from injection.
- Size caps (200KB / 150KB) keep the argv well under `ARG_MAX`.

## Test plan
- [ ] `/cursor review` on an open PR posts a real, content-aware review.

Made with [Cursor](https://cursor.com)