### PR TITLE
docs(charts): fill NOTES gaps for Discord + Coordinator knowledge APIs

### DIFF
--- a/charts/kprompt-agent/templates/NOTES.txt
+++ b/charts/kprompt-agent/templates/NOTES.txt
@@ -8,9 +8,22 @@ kprompt-agent installed.
    - Helm defaults keep apply=false. There is no silent LLM-said-so apply.
 4. Secret {{ include "kprompt-agent.secretName" . }} — put LLM / Slack / webhook keys, then restart if needed:
      kubectl -n {{ include "kprompt-agent.watchNamespace" . }} rollout restart deploy/{{ include "kprompt-agent.fullname" . }}
-5. Logs:
+{{ if .Values.agent.discord }}
+
+5. Discord notifications are enabled (`agent.discord=true` / `--discord`):
+   - Put `KPROMPT_DISCORD_WEBHOOK_URL` in Secret {{ include "kprompt-agent.secretName" . }}.
+   - The Deployment imports this key automatically when `envFromSecret=true`.
+   - To create or update the Secret without committing the webhook:
+       export DISCORD_WEBHOOK_URL='<set-out-of-band>'
+       kubectl -n {{ include "kprompt-agent.watchNamespace" . }} create secret generic {{ include "kprompt-agent.secretName" . }} \
+         --from-literal=KPROMPT_DISCORD_WEBHOOK_URL="$DISCORD_WEBHOOK_URL" \
+         --dry-run=client -o yaml | kubectl apply -f -
+{{ else }}
+5. Discord notifications are disabled by default. Set `agent.discord=true` to enable them.
+{{ end }}
+6. Logs:
      kubectl -n {{ include "kprompt-agent.watchNamespace" . }} logs -l app.kubernetes.io/instance={{ .Release.Name }} -f
-6. Docs:
+7. Docs:
      https://github.com/kprompt/kprompt/blob/main/docs/agent.md
      https://github.com/kprompt/kprompt/blob/main/docs/namespace-agent.md
      https://github.com/kprompt/kprompt/blob/main/docs/agent-ops.md

--- a/charts/kprompt-agent/templates/NOTES.txt
+++ b/charts/kprompt-agent/templates/NOTES.txt
@@ -13,11 +13,10 @@ kprompt-agent installed.
 5. Discord notifications are enabled (`agent.discord=true` / `--discord`):
    - Put `KPROMPT_DISCORD_WEBHOOK_URL` in Secret {{ include "kprompt-agent.secretName" . }}.
    - The Deployment imports this key automatically when `envFromSecret=true`.
-   - To create or update the Secret without committing the webhook:
+   - To set or update the webhook key without overwriting other keys in that Secret (merge patch):
        export DISCORD_WEBHOOK_URL='<set-out-of-band>'
-       kubectl -n {{ include "kprompt-agent.watchNamespace" . }} create secret generic {{ include "kprompt-agent.secretName" . }} \
-         --from-literal=KPROMPT_DISCORD_WEBHOOK_URL="$DISCORD_WEBHOOK_URL" \
-         --dry-run=client -o yaml | kubectl apply -f -
+       kubectl -n {{ include "kprompt-agent.watchNamespace" . }} patch secret {{ include "kprompt-agent.secretName" . }} \
+         --type merge -p "{\"stringData\":{\"KPROMPT_DISCORD_WEBHOOK_URL\":\"$DISCORD_WEBHOOK_URL\"}}"
 {{ else }}
 5. Discord notifications are disabled by default. Set `agent.discord=true` to enable them.
 {{ end }}

--- a/charts/kprompt-coordinator/README.md
+++ b/charts/kprompt-coordinator/README.md
@@ -66,6 +66,7 @@ Ops checklist: [docs/agent-ops.md](../../docs/agent-ops.md#worker-isolation-ag-0
 | `service.port` | `9090` | HTTP API |
 | `rbac.clusterRole.create` | `false` | Keep minimal |
 | `probe.enabled` | `false` | Passes `--probe-kube --in-cluster` |
+| `knowledge.enabled` | `true` | Persists the Shared Knowledge handoff ring in a ConfigMap and enables the durable knowledge backend |
 | `rbac.probeNamespaces` | `[]` | RoleBindings for AG-050 probe |
 
 See [docs/namespace-agent.md](../../docs/namespace-agent.md) · [docs/agent-ops.md](../../docs/agent-ops.md).

--- a/charts/kprompt-coordinator/templates/NOTES.txt
+++ b/charts/kprompt-coordinator/templates/NOTES.txt
@@ -8,13 +8,17 @@ kprompt-coordinator installed.
      http://{{ include "kprompt-coordinator.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/v1/handoff
 2. On each Namespace Agent, point handoff traffic at the Coordinator:
      --coordinator-url http://{{ include "kprompt-coordinator.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/v1/handoff
-3. RBAC / safety:
+3. Check the Coordinator APIs from inside the cluster:
+     curl -fsS http://{{ include "kprompt-coordinator.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/v1/knowledge
+     curl -fsS "http://{{ include "kprompt-coordinator.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/v1/blast-radius?namespace=<namespace>"
+   Shared Knowledge persistence is {{ if .Values.knowledge.enabled }}enabled{{ else }}disabled{{ end }} (`knowledge.enabled={{ .Values.knowledge.enabled }}`).
+4. RBAC / safety:
    - Coordinator is ServiceAccount-only by default.
    - rbac.clusterRole.create={{ .Values.rbac.clusterRole.create | default false }} keeps cluster-wide reads off unless you opt in.
    - Coordinator never mutates workloads. Do not grant create/update/patch/delete on workloads.
-4. Logs:
+5. Logs:
      kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/instance={{ .Release.Name }} -f
-5. Docs:
+6. Docs:
      https://github.com/kprompt/kprompt/blob/main/charts/kprompt-coordinator/README.md
      https://github.com/kprompt/kprompt/blob/main/docs/namespace-agent.md
      https://github.com/kprompt/kprompt/blob/main/docs/agent-ops.md


### PR DESCRIPTION
## Summary

Fills the post-install NOTES gaps called out in #108:

- **Agent chart** — documents the Discord notify enable path (`agent.discord` -> `--discord`) and the `KPROMPT_DISCORD_WEBHOOK_URL` secret key, with a copy-pasteable Secret upsert that keeps the webhook out of git.
- **Coordinator chart** — adds short curl/check examples for `/v1/knowledge` and `/v1/blast-radius?namespace=<namespace>`, and surfaces `knowledge.enabled` in the Coordinator chart README values table.

## Acceptance checklist

- [x] Agent NOTES.txt: Discord enable path + secret key hint when Discord is configured
- [x] Coordinator NOTES.txt: short curl/check examples for knowledge + blast-radius endpoints
- [x] Coordinator chart README Values mentions `knowledge.enabled` (or equivalent)
- [x] No secrets committed — placeholders only

## Notes

- Docs-only change; verified the referenced values (`agent.discord`, `envFromSecret`, `knowledge.enabled`) and endpoints (`/v1/knowledge`, `/v1/blast-radius`) exist in the chart values and coordinator HTTP routes.
- `git diff --check` clean. helm template smoke not run locally (helm CLI not installed); CI will validate the chart.

Fixes #108
