### PR TITLE
feat(cluster): extend --wait to DaemonSet readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ See also: [GitHub Integration MVP / GitOps PR mode](./docs/gitops-pr.md). Exampl
 |------|-------------|
 | `--approve` | Apply without interactive confirmation |
 | `--approve-each-context` | Apply a mutating plan to every `--contexts` entry (explicit; not implied by `--approve`) |
-| `--wait` | After apply, wait for Deployment rollout, then verify |
+| `--wait` | After apply, wait for Deployment / StatefulSet / DaemonSet rollout, then verify |
 | `--timeout` | Timeout for `--wait` (default `5m`) |
 | `--output` / `-o` | `text` (default) or `json` (CI PlanResult) |
 | `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `openrouter`, `together`, `ollama`, `openai-compatible` |

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -107,7 +107,7 @@ Bare kprompt (no args) prints a readiness coach. Full help: kprompt --help · kp
 
 	root.PersistentFlags().BoolVar(&approve, "approve", false, "apply the plan without interactive confirmation")
 	root.PersistentFlags().BoolVar(&approveEachContext, "approve-each-context", false, "apply a mutating plan to every --contexts entry (explicit; not implied by --approve)")
-	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment/StatefulSet rollout to complete")
+	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment/StatefulSet/DaemonSet rollout to complete")
 	root.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for --wait (default 5m)")
 	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|openrouter|together|ollama|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")

--- a/internal/cluster/wait.go
+++ b/internal/cluster/wait.go
@@ -168,3 +168,67 @@ func DesiredSTSReplicas(sts *appsv1.StatefulSet) int32 {
 	}
 	return 1
 }
+
+// WaitDaemonSet blocks until the DaemonSet is fully available or timeout.
+func (w *Waiter) WaitDaemonSet(ctx context.Context, namespace, name string, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = DefaultWaitTimeout
+	}
+	ns := namespace
+	if ns == "" {
+		ns = "default"
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if w.Out != nil {
+		fmt.Fprintf(w.Out, "Waiting for DaemonSet/%s -n %s (timeout %s)…\n", name, ns, timeout)
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	var last *appsv1.DaemonSet
+	for {
+		ds, err := w.Client.AppsV1().DaemonSets(ns).Get(waitCtx, name, metav1.GetOptions{})
+		if err != nil {
+			if waitCtx.Err() != nil && !errors.Is(err, context.Canceled) {
+				return timeoutDSErr(name, timeout, last)
+			}
+			return err
+		}
+		last = ds
+		if daemonSetReady(ds) {
+			if w.Out != nil {
+				fmt.Fprintf(w.Out, "✓ DaemonSet/%s ready\n", name)
+			}
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return timeoutDSErr(name, timeout, last)
+			}
+			return waitCtx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func timeoutDSErr(name string, timeout time.Duration, ds *appsv1.DaemonSet) error {
+	if ds == nil {
+		return fmt.Errorf("timed out waiting for DaemonSet/%s after %s", name, timeout)
+	}
+	return fmt.Errorf("timed out waiting for DaemonSet/%s after %s (updated=%d ready=%d desired=%d)",
+		name, timeout, ds.Status.UpdatedNumberScheduled, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled)
+}
+
+func daemonSetReady(ds *appsv1.DaemonSet) bool {
+	desired := ds.Status.DesiredNumberScheduled
+	if desired == 0 {
+		return false
+	}
+	return ds.Status.ObservedGeneration >= ds.Generation &&
+		ds.Status.UpdatedNumberScheduled == desired &&
+		ds.Status.NumberReady == desired
+}

--- a/internal/cluster/wait_test.go
+++ b/internal/cluster/wait_test.go
@@ -139,3 +139,76 @@ func TestStatefulSetComplete(t *testing.T) {
 		t.Fatal("expected incomplete")
 	}
 }
+
+func TestWaitDaemonSetAlreadyReady(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "fluentd", Namespace: "default", Generation: 1},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     1,
+			DesiredNumberScheduled: 3,
+			UpdatedNumberScheduled: 3,
+			NumberReady:            3,
+		},
+	})
+	var out bytes.Buffer
+	err := (&Waiter{Client: client, Out: &out}).WaitDaemonSet(context.Background(), "default", "fluentd", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "ready") {
+		t.Fatalf("output=%q", out.String())
+	}
+}
+
+func TestWaitDaemonSetTimeout(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "fluent-log", Namespace: "default", Generation: 2},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     1,
+			DesiredNumberScheduled: 3,
+			UpdatedNumberScheduled: 1,
+			NumberReady:            1,
+		},
+	})
+	err := (&Waiter{Client: client}).WaitDaemonSet(context.Background(), "default", "fluent-log", 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for DaemonSet/fluent-log") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestDaemonSetReady(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     2,
+			DesiredNumberScheduled: 5,
+			UpdatedNumberScheduled: 5,
+			NumberReady:            5,
+		},
+	}
+	if !daemonSetReady(ds) {
+		t.Fatal("expected ready")
+	}
+	ds.Status.NumberReady = 3
+	if daemonSetReady(ds) {
+		t.Fatal("expected not ready")
+	}
+}
+
+func TestDaemonSetReadyDesiredZero(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Generation: 1},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     1,
+			DesiredNumberScheduled: 0,
+			UpdatedNumberScheduled: 0,
+			NumberReady:            0,
+		},
+	}
+	if daemonSetReady(ds) {
+		t.Fatal("expected not ready when desired=0")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1353,6 +1353,8 @@ func RunWith(ctx context.Context, cfg config.Resolved, out io.Writer, deps Deps)
 				err = waiter.WaitDeployment(ctx, t.Namespace, t.Name, timeout)
 			case "StatefulSet":
 				err = waiter.WaitStatefulSet(ctx, t.Namespace, t.Name, timeout)
+			case "DaemonSet":
+				err = waiter.WaitDaemonSet(ctx, t.Namespace, t.Name, timeout)
 			default:
 				fmt.Fprintf(out, "Skipping --wait for unsupported resource kind %s\n", t.Kind)
 				continue
@@ -1395,21 +1397,21 @@ func deploymentWaitTargets(plan planner.ExecutionPlan) []planner.ObjectRef {
 	for _, a := range plan.Actions {
 		switch a.Op {
 		case planner.OpScale, planner.OpRollback, planner.OpCreate, planner.OpUpdate:
-			if a.Object.Kind != "Deployment" && a.Object.Kind != "StatefulSet" && a.Object.Kind != "" {
+			if a.Object.Kind != "Deployment" && a.Object.Kind != "StatefulSet" && a.Object.Kind != "DaemonSet" && a.Object.Kind != "" {
 				continue
 			}
-			key := a.Object.Namespace + "/" + a.Object.Name
-			if a.Object.Name == "" {
-				continue
-			}
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
 			ref := a.Object
 			if ref.Kind == "" {
 				ref.Kind = "Deployment"
 			}
+			if ref.Name == "" {
+				continue
+			}
+			key := ref.Kind + "/" + ref.Namespace + "/" + ref.Name
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
 			out = append(out, ref)
 		}
 	}

--- a/internal/pipeline/wait_targets_test.go
+++ b/internal/pipeline/wait_targets_test.go
@@ -1,0 +1,50 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kprompt/kprompt/internal/planner"
+)
+
+func TestDeploymentWaitTargetsIncludesDaemonSets(t *testing.T) {
+	plan := planner.ExecutionPlan{Actions: []planner.Action{
+		{Op: planner.OpCreate, Object: planner.ObjectRef{Kind: "Deployment", Namespace: "default", Name: "api"}},
+		{Op: planner.OpUpdate, Object: planner.ObjectRef{Kind: "StatefulSet", Namespace: "default", Name: "db"}},
+		{Op: planner.OpScale, Object: planner.ObjectRef{Kind: "DaemonSet", Namespace: "default", Name: "node-agent"}},
+		{Op: planner.OpCreate, Object: planner.ObjectRef{Kind: "Service", Namespace: "default", Name: "api"}},
+		{Op: planner.OpCreate, Object: planner.ObjectRef{Kind: "DaemonSet", Namespace: "default", Name: "node-agent"}},
+	}}
+
+	got := deploymentWaitTargets(plan)
+	if len(got) != 3 {
+		t.Fatalf("got %d wait targets, want 3: %+v", len(got), got)
+	}
+	for _, want := range []planner.ObjectRef{
+		{Kind: "Deployment", Namespace: "default", Name: "api"},
+		{Kind: "StatefulSet", Namespace: "default", Name: "db"},
+		{Kind: "DaemonSet", Namespace: "default", Name: "node-agent"},
+	} {
+		found := false
+		for _, ref := range got {
+			if ref == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing wait target %+v in %+v", want, got)
+		}
+	}
+}
+
+func TestDeploymentWaitTargetsDistinguishesKindsWithSameName(t *testing.T) {
+	plan := planner.ExecutionPlan{Actions: []planner.Action{
+		{Op: planner.OpCreate, Object: planner.ObjectRef{Kind: "Deployment", Namespace: "default", Name: "agent"}},
+		{Op: planner.OpCreate, Object: planner.ObjectRef{Kind: "DaemonSet", Namespace: "default", Name: "agent"}},
+	}}
+
+	got := deploymentWaitTargets(plan)
+	if len(got) != 2 {
+		t.Fatalf("got %d wait targets, want 2: %+v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Summary

Extends `--wait` so DaemonSet applies are actually waited on, closing the gap where apply/verify/audit already understood DaemonSets but `deploymentWaitTargets` skipped them.

## Changes

- **`internal/cluster/wait.go`** — new `WaitDaemonSet` that polls until the DaemonSet is rolled out or the timeout expires. `daemonSetReady` mirrors the existing verify heuristics in `internal/verify` (`ready == desired && updated == desired`; `desired=0` is not treated as ready) plus the `ObservedGeneration >= Generation` guard already used by the Deployment/StatefulSet checks.
- **`internal/pipeline/pipeline.go`** — `deploymentWaitTargets` now includes `DaemonSet`, and the wait switch calls `WaitDaemonSet`. Unsupported kinds still skip with a clear message (no fake success).
- **`cmd/kprompt/main.go` + `README.md`** — `--wait` help now lists Deployment / StatefulSet / DaemonSet.
- **Tests** — fake-clientset unit tests for `WaitDaemonSet` (already-ready + timeout), `daemonSetReady` (ready / not-ready / desired=0), and wait-target coverage proving DaemonSet inclusion plus kind-aware dedup (a Deployment and DaemonSet sharing a name are both waited on).

## Acceptance checklist

- [x] `WaitDaemonSet` blocks until desired/updated/ready counts match (mirrors verify DaemonSet heuristics)
- [x] `deploymentWaitTargets` includes DaemonSet; pipeline switch calls `WaitDaemonSet`
- [x] Unsupported kinds still skip with a clear human message (never fake success)
- [x] `--wait` flag help + README Flags mention Deployment / StatefulSet / DaemonSet
- [x] Unit tests: fake client ready + timeout pending

## Verification

- `go test ./internal/cluster/ ./internal/pipeline/` — pass
- `go build ./cmd/kprompt` — pass
- `git diff --check` — clean
- gofmt-clean (checked via LF-normalized copy; the working tree is CRLF)

Fixes #106
