### PR TITLE
ci: fix CodeQL Go extraction and pin action to SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,14 +21,15 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      # TODO: pin codeql-action to a commit SHA to match the repo's action-pinning policy.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: go
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+      # Autobuild fails to extract this module ("Extraction failed for all
+      # discovered Go projects"), so build explicitly for reliable extraction.
+      - name: Build
+        run: go build ./...
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:go"


### PR DESCRIPTION
## Summary
- Replace CodeQL `autobuild` with an explicit `go build ./...`. Autobuild was failing with "Extraction failed for all discovered Go projects", turning the **Analyze (go)** check red on open PRs (e.g. #139, #121).
- Pin `github/codeql-action/init` and `analyze` to a commit SHA (`5595ccaf` / v4), matching the repo's action-pinning policy (removes the stale `TODO`).

## Test plan
- [ ] CodeQL workflow runs on this PR and **Analyze (go)** passes.
- [ ] `go build ./...` succeeds (verified locally).

Made with [Cursor](https://cursor.com)