### PR TITLE
ci: auto-merge approved PRs once branch protection is satisfied

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,39 @@
+name: auto-merge
+
+# Enable GitHub's native auto-merge on eligible PRs. This does NOT bypass any
+# gate: GitHub still waits for branch protection to be satisfied (required
+# approving review + the required "test" status check) before merging. We only
+# remove the manual "click Merge" step once a human has approved and CI is green.
+#
+# Security model:
+# - Runs from the base branch (pull_request_target) and never checks out or runs
+#   the PR head code — it only calls the `gh` API. A malicious fork cannot change
+#   what runs here or force a merge without passing branch protection.
+# - Drafts and Dependabot PRs are skipped.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable:
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --auto --squash


### PR DESCRIPTION
## Summary
- Add `.github/workflows/auto-merge.yml` that enables GitHub's **native auto-merge** (squash) on non-draft, non-Dependabot PRs.
- Branch protection still gates everything: a PR only merges after **1 approving review** + the required **test** check pass. This just removes the manual "Merge" click once a human approves and CI is green.
- Repo setting `allow_auto_merge` has been enabled to support this.

## Security
- Uses `pull_request_target` and never checks out or runs PR head code (only `gh` API calls), so a fork cannot force a merge or change what runs.

## Test plan
- [ ] Approve a test PR with green `test` check → it merges automatically.
- [ ] A PR without approval stays open (auto-merge queued, not merged).

Made with [Cursor](https://cursor.com)