### PR TITLE
feat(llm): add Fireworks provider preset (P-003)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ The `kp_…` token is stored only in `credentials.yaml` (0600), never in `config
 | `--wait` | After apply, wait for Deployment / StatefulSet / DaemonSet rollout, then verify |
 | `--timeout` | Timeout for `--wait` (default `5m`) |
 | `--output` / `-o` | `text` (default) or `json` (CI PlanResult) |
-| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `openrouter`, `together`, `ollama`, `azure`, `openai-compatible` |
+| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `openrouter`, `together`, `fireworks`, `ollama`, `azure`, `openai-compatible` |
 | `--model` | Model id |
 | `--context` | kubeconfig context |
 | `--contexts` | Comma-separated contexts for read fan-out / per-context mutate |

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -109,7 +109,7 @@ Bare kprompt (no args) prints a readiness coach. Full help: kprompt --help · kp
 	root.PersistentFlags().BoolVar(&approveEachContext, "approve-each-context", false, "apply a mutating plan to every --contexts entry (explicit; not implied by --approve)")
 	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment/StatefulSet/DaemonSet rollout to complete")
 	root.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for --wait (default 5m)")
-	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|openrouter|together|ollama|azure|openai-compatible)")
+	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|openrouter|together|fireworks|ollama|azure|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")
 	root.PersistentFlags().StringVar(&kubeCtx, "context", "", "kubeconfig context")
 	root.PersistentFlags().StringVar(&kubeCtxs, "contexts", "", "comma-separated contexts for read fan-out / per-context mutate (aliases ok)")

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -25,6 +25,7 @@ Optional Team `kp_…` tokens (`kprompt login`) are for org policy/audit — not
 | Moonshot (Kimi K3) | `moonshot` | `KPROMPT_MOONSHOT_API_KEY` / `MOONSHOT_API_KEY` | `kimi-k3` | OpenAI-compatible |
 | OpenRouter | `openrouter` | `KPROMPT_OPENROUTER_API_KEY` / `OPENROUTER_API_KEY` | `openai/gpt-4o-mini` | OpenAI-compatible |
 | Together | `together` | `KPROMPT_TOGETHER_API_KEY` / `TOGETHER_API_KEY` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | OpenAI-compatible |
+| Fireworks | `fireworks` | `KPROMPT_FIREWORKS_API_KEY` / `FIREWORKS_API_KEY` | `accounts/fireworks/models/llama-v3p3-70b-instruct` | OpenAI-compatible |
 | Generic OpenAI-compat | `openai-compatible` | `KPROMPT_OPENAI_API_KEY` | — | **Requires** `base_url` |
 | Azure OpenAI | `azure` | `KPROMPT_AZURE_API_KEY` / `AZURE_OPENAI_API_KEY` / `KPROMPT_OPENAI_API_KEY` | `gpt-4o` | OpenAI-compatible; **Requires** `base_url` (resource URL). `--model` is your **deployment name**, not an OpenAI model id |
 
@@ -100,6 +101,11 @@ kprompt --provider openai-compatible --model gpt-4o-mini "list services"
 export KPROMPT_AZURE_API_KEY=...
 export KPROMPT_OPENAI_BASE_URL=https://YOUR_RESOURCE.openai.azure.com/openai/v1
 kprompt --provider azure --model my-gpt4o-deploy "list services"
+
+# Fireworks
+export KPROMPT_FIREWORKS_API_KEY=...
+kprompt init --provider fireworks
+kprompt "list deployments"
 ```
 
 On Azure, `--model` carries the **deployment name** you chose in the portal — not an OpenAI

--- a/internal/llm/presets.go
+++ b/internal/llm/presets.go
@@ -128,6 +128,14 @@ var Presets = []Preset{
 		EnvKeys:      []string{"KPROMPT_TOGETHER_API_KEY", "TOGETHER_API_KEY"},
 		HelpURL:      "https://api.together.xyz/",
 	},
+	{
+		Name:         "fireworks",
+		Kind:         "openai",
+		BaseURL:      "https://api.fireworks.ai/inference/v1",
+		DefaultModel: "accounts/fireworks/models/llama-v3p3-70b-instruct",
+		EnvKeys:      []string{"KPROMPT_FIREWORKS_API_KEY", "FIREWORKS_API_KEY"},
+		HelpURL:      "https://fireworks.ai/account/api-keys",
+	},
 }
 
 // LookupPreset finds a preset by name (case-insensitive).

--- a/internal/llm/presets_test.go
+++ b/internal/llm/presets_test.go
@@ -63,7 +63,10 @@ func TestLookupPresetCerebras(t *testing.T) {
 
 func TestSupportedNamesIncludesNewProviders(t *testing.T) {
 	s := SupportedNames()
-	for _, want := range []string{"openai", "anthropic", "gemini", "groq", "mistral", "deepseek", "moonshot", "ollama", "openrouter", "together", "xai", "cerebras", "azure"} {
+	wantNames := []string{"openai", "anthropic", "gemini", "groq",
+		"mistral", "deepseek", "moonshot", "ollama", "openrouter",
+		"together", "xai", "cerebras", "azure", "fireworks"}
+	for _, want := range wantNames {
 		if !contains(s, want) {
 			t.Fatalf("%q missing from %s", want, s)
 		}


### PR DESCRIPTION
Fixes #54

Completed these
kprompt/internal/llm/presets.go — add Preset
kprompt/internal/llm/presets_test.go — assert name in SupportedNames
kprompt/cmd/kprompt/main.go — --provider help string
kprompt/docs/providers.md — table row + example
kprompt/README.md — flags table (+ optional env example)
go test ./internal/llm/ green 

Please let me know if you want changes made

I will do the separate changes in website now