### PR TITLE
test(ainative): cover LooksLikeSession/Remember/WatchPrompt (#155)

### DIFF
--- a/internal/intent/ainative_test.go
+++ b/internal/intent/ainative_test.go
@@ -1,0 +1,70 @@
+package intent
+
+import "testing"
+
+func TestLooksLikeSessionPrompt(t *testing.T) {
+	yes := []string{
+		"what did I do today",
+		"session summary",
+		"todays history",
+	}
+	for _, p := range yes {
+		if !LooksLikeSessionPrompt(p) {
+			t.Fatalf("expected match for %q", p)
+		}
+	}
+	no := []string{
+		"watch cluster",
+		"remember that",
+		"cluster vibe check",
+	}
+	for _, p := range no {
+		if LooksLikeSessionPrompt(p) {
+			t.Fatalf("unexpected match for %q", p)
+		}
+	}
+}
+
+func TestLooksLikeRememberPrompt(t *testing.T) {
+	yes := []string{
+		"remember that",
+		"forget list",
+	}
+	for _, p := range yes {
+		if !LooksLikeRememberPrompt(p) {
+			t.Fatalf("expected match for %q", p)
+		}
+	}
+	no := []string{
+		"watch cluster",
+		"todays history",
+	}
+	for _, p := range no {
+		if LooksLikeRememberPrompt(p) {
+			t.Fatalf("unexpected match for %q", p)
+		}
+	}
+}
+
+func TestLooksLikeWatchPrompt(t *testing.T) {
+	yes := []string{
+		"watch the cluster",
+		"proactive assist",
+		"watch payments",
+	}
+	for _, p := range yes {
+		if !LooksLikeWatchPrompt(p) {
+			t.Fatalf("expected match for %q", p)
+		}
+	}
+	no := []string{
+		"how's my cluster",
+		"cluster vibe check",
+		"roast my cluster",
+	}
+	for _, p := range no {
+		if LooksLikeWatchPrompt(p) {
+			t.Fatalf("unexpected match for %q", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #155

## Changes

- Add table-driven tests in `internal/intent/ainative_test.go` for `LooksLikeSessionPrompt`, `LooksLikeRememberPrompt` and `LooksLikeWatchPrompt`. For expected matches and unexpected matches for each function.

- Add a roast prompt to test that `LooksLikeWatchPrompt` does not match

- `go test ./internal/intent/...` is green

- No changes to production code

## Note

- I may be wrong, but I’m not sure explicitly checking for roast prompts and then rejecting them adds much value. It looks like `LooksLikeWatchPrompt` is only called after roast prompts have already been checked in the pipeline and returns if it’s a roast prompt. So it seems like it’s just checking twice, although the explicit check does make it clearer. Not a big thing, but I thought I’d point it out. I did not make any changes to `LooksLikeWatchPrompt`.