### PR TITLE
test: cover detector helpers (#154)

### DIFF
--- a/internal/tools/crossplane/detect_test.go
+++ b/internal/tools/crossplane/detect_test.go
@@ -1,0 +1,62 @@
+package crossplane
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "CompositeResourceDefinition CRD not found (apiextensions.crossplane.io)",
+		},
+		{
+			name: "installed without versions",
+			av:   Availability{Installed: true},
+			want: "Crossplane XRD API present",
+		},
+		{
+			name: "installed with version",
+			av: Availability{
+				Installed: true,
+				Group:     XRDGroup,
+				Kind:      XRDKind,
+				Versions:  []string{"v1"},
+			},
+			want: "Crossplane XRD API present (apiextensions.crossplane.io/CompositeResourceDefinition: v1)",
+		},
+		{
+			name: "installed with multiple versions",
+			av: Availability{
+				Installed: true,
+				Group:     XRDGroup,
+				Kind:      XRDKind,
+				Versions:  []string{"v1", "v1beta1"},
+			},
+			want: "Crossplane XRD API present (apiextensions.crossplane.io/CompositeResourceDefinition: v1, v1beta1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	if !strings.Contains(strings.ToLower(hint), "crossplane") {
+		t.Fatalf("InstallHint() = %q, want Crossplane reference", hint)
+	}
+}

--- a/internal/tools/gitops/detect_test.go
+++ b/internal/tools/gitops/detect_test.go
@@ -1,0 +1,65 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabelCases(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "Flux Kustomization / Argo CD Application CRDs not found",
+		},
+		{
+			name: "flux installed",
+			av: Availability{
+				Installed: true,
+				Flux:      true,
+			},
+			want: "Flux Kustomization present",
+		},
+		{
+			name: "argo cd installed",
+			av: Availability{
+				Installed: true,
+				ArgoCD:    true,
+			},
+			want: "Argo CD Application present",
+		},
+		{
+			name: "flux and argo cd installed",
+			av: Availability{
+				Installed: true,
+				Flux:      true,
+				ArgoCD:    true,
+			},
+			want: "Flux Kustomization + Argo CD Application present",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	lowerHint := strings.ToLower(hint)
+	for _, product := range []string{"flux", "argo cd"} {
+		if !strings.Contains(lowerHint, product) {
+			t.Fatalf("InstallHint() = %q, want %s reference", hint, product)
+		}
+	}
+}

--- a/internal/tools/istio/detect_test.go
+++ b/internal/tools/istio/detect_test.go
@@ -1,0 +1,62 @@
+package istio
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "VirtualService CRD not found (networking.istio.io/VirtualService)",
+		},
+		{
+			name: "installed without versions",
+			av:   Availability{Installed: true},
+			want: "VirtualService CRD present",
+		},
+		{
+			name: "installed with version",
+			av: Availability{
+				Installed: true,
+				Group:     VirtualServiceGroup,
+				Kind:      VirtualServiceKind,
+				Versions:  []string{"v1beta1"},
+			},
+			want: "VirtualService CRD present (networking.istio.io/VirtualService: v1beta1)",
+		},
+		{
+			name: "installed with multiple versions",
+			av: Availability{
+				Installed: true,
+				Group:     VirtualServiceGroup,
+				Kind:      VirtualServiceKind,
+				Versions:  []string{"v1beta1", "v1alpha3"},
+			},
+			want: "VirtualService CRD present (networking.istio.io/VirtualService: v1beta1, v1alpha3)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	if !strings.Contains(strings.ToLower(hint), "istio") {
+		t.Fatalf("InstallHint() = %q, want Istio reference", hint)
+	}
+}

--- a/internal/tools/keda/detect_test.go
+++ b/internal/tools/keda/detect_test.go
@@ -1,0 +1,62 @@
+package keda
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "ScaledObject CRD not found (keda.sh/ScaledObject)",
+		},
+		{
+			name: "installed without versions",
+			av:   Availability{Installed: true},
+			want: "ScaledObject CRD present",
+		},
+		{
+			name: "installed with version",
+			av: Availability{
+				Installed: true,
+				Group:     ScaledObjectGroup,
+				Kind:      ScaledObjectKind,
+				Versions:  []string{"v1alpha1"},
+			},
+			want: "ScaledObject CRD present (keda.sh/ScaledObject: v1alpha1)",
+		},
+		{
+			name: "installed with multiple versions",
+			av: Availability{
+				Installed: true,
+				Group:     ScaledObjectGroup,
+				Kind:      ScaledObjectKind,
+				Versions:  []string{"v1alpha1", "v1beta1"},
+			},
+			want: "ScaledObject CRD present (keda.sh/ScaledObject: v1alpha1, v1beta1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	if !strings.Contains(strings.ToLower(hint), "keda") {
+		t.Fatalf("InstallHint() = %q, want KEDA reference", hint)
+	}
+}

--- a/internal/tools/tekton/detect_test.go
+++ b/internal/tools/tekton/detect_test.go
@@ -1,0 +1,62 @@
+package tekton
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetailLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		av   Availability
+		want string
+	}{
+		{
+			name: "not installed",
+			want: "PipelineRun CRD not found (tekton.dev/PipelineRun)",
+		},
+		{
+			name: "installed without versions",
+			av:   Availability{Installed: true},
+			want: "PipelineRun CRD present",
+		},
+		{
+			name: "installed with version",
+			av: Availability{
+				Installed: true,
+				Group:     PipelineGroup,
+				Kind:      PipelineRunKind,
+				Versions:  []string{"v1"},
+			},
+			want: "PipelineRun CRD present (tekton.dev/PipelineRun: v1)",
+		},
+		{
+			name: "installed with multiple versions",
+			av: Availability{
+				Installed: true,
+				Group:     PipelineGroup,
+				Kind:      PipelineRunKind,
+				Versions:  []string{"v1", "v1beta1"},
+			},
+			want: "PipelineRun CRD present (tekton.dev/PipelineRun: v1, v1beta1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetailLabel(tt.av); got != tt.want {
+				t.Fatalf("DetailLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallHint(t *testing.T) {
+	hint := InstallHint()
+	if hint == "" {
+		t.Fatal("expected install hint")
+	}
+	if !strings.Contains(strings.ToLower(hint), "tekton") {
+		t.Fatalf("InstallHint() = %q, want Tekton reference", hint)
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Why this change exists. Link issues if any. -->

## Changes

-

## Test plan

- [ ] `go test ./...` (CLI) and/or website checks as applicable
- [ ] Manual: relevant `kprompt "..."` prompts / install path verified
- [ ] No secrets, kubeconfigs, or API keys in the diff
