### PR TITLE
feat(llm): add Qwen/DashScope provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ The `kp_…` token is stored only in `credentials.yaml` (0600), never in `config
 | `--wait` | After apply, wait for Deployment / StatefulSet / DaemonSet rollout, then verify |
 | `--timeout` | Timeout for `--wait` (default `5m`) |
 | `--output` / `-o` | `text` (default) or `json` (CI PlanResult) |
-| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `openrouter`, `together`, `fireworks`, `ollama`, `azure`, `openai-compatible` |
+| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `qwen`, `openrouter`, `together`, `fireworks`, `ollama`, `azure`, `openai-compatible` |
 | `--model` | Model id |
 | `--context` | kubeconfig context |
 | `--contexts` | Comma-separated contexts for read fan-out / per-context mutate |

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -109,7 +109,7 @@ Bare kprompt (no args) prints a readiness coach. Full help: kprompt --help · kp
 	root.PersistentFlags().BoolVar(&approveEachContext, "approve-each-context", false, "apply a mutating plan to every --contexts entry (explicit; not implied by --approve)")
 	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment/StatefulSet/DaemonSet rollout to complete")
 	root.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for --wait (default 5m)")
-	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|openrouter|together|fireworks|ollama|azure|openai-compatible)")
+	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|qwen|openrouter|together|fireworks|ollama|azure|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")
 	root.PersistentFlags().StringVar(&kubeCtx, "context", "", "kubeconfig context")
 	root.PersistentFlags().StringVar(&kubeCtxs, "contexts", "", "comma-separated contexts for read fan-out / per-context mutate (aliases ok)")

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -23,6 +23,7 @@ Optional Team `kp_…` tokens (`kprompt login`) are for org policy/audit — not
 | Mistral | `mistral` | `KPROMPT_MISTRAL_API_KEY` / `MISTRAL_API_KEY` | `mistral-small-latest` | OpenAI-compatible |
 | DeepSeek | `deepseek` | `KPROMPT_DEEPSEEK_API_KEY` / `DEEPSEEK_API_KEY` | `deepseek-chat` | OpenAI-compatible |
 | Moonshot (Kimi K3) | `moonshot` | `KPROMPT_MOONSHOT_API_KEY` / `MOONSHOT_API_KEY` | `kimi-k3` | OpenAI-compatible |
+| Qwen (DashScope) | `qwen` | `KPROMPT_QWEN_API_KEY` / `DASHSCOPE_API_KEY` / `QWEN_API_KEY` | `qwen-plus` | OpenAI-compatible; intl endpoint — see note below |
 | OpenRouter | `openrouter` | `KPROMPT_OPENROUTER_API_KEY` / `OPENROUTER_API_KEY` | `openai/gpt-4o-mini` | OpenAI-compatible |
 | Together | `together` | `KPROMPT_TOGETHER_API_KEY` / `TOGETHER_API_KEY` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | OpenAI-compatible |
 | Fireworks | `fireworks` | `KPROMPT_FIREWORKS_API_KEY` / `FIREWORKS_API_KEY` | `accounts/fireworks/models/llama-v3p3-70b-instruct` | OpenAI-compatible |
@@ -54,6 +55,22 @@ kprompt init --ollama
 ```
 
 Monitor Google quotas: [ai.dev/rate-limit](https://ai.dev/rate-limit).
+
+## Qwen / DashScope regions
+
+The `qwen` preset defaults to Alibaba Cloud's **international** DashScope endpoint
+(`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`). Mainland China accounts use a
+separate endpoint and key pool — if your key was issued on the CN console, override the base
+URL:
+
+```bash
+export KPROMPT_QWEN_API_KEY=...        # or DASHSCOPE_API_KEY / QWEN_API_KEY
+export KPROMPT_OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1  # CN mainland
+kprompt --provider qwen "explain why api is crashlooping"
+```
+
+Intl and CN keys are **not interchangeable** — a CN-issued key against the intl endpoint (or
+vice versa) fails auth.
 
 ## Examples
 
@@ -91,6 +108,10 @@ kprompt --provider cerebras "list pods"
 # Moonshot / Kimi K3
 export KPROMPT_MOONSHOT_API_KEY=...
 kprompt --provider moonshot "explain why api is crashlooping"
+
+# Qwen / DashScope (intl; see regional note above for CN mainland)
+export KPROMPT_QWEN_API_KEY=...
+kprompt --provider qwen "explain why api is crashlooping"
 
 # Custom gateway / any OpenAI-compatible endpoint
 export KPROMPT_OPENAI_API_KEY=...

--- a/internal/llm/presets.go
+++ b/internal/llm/presets.go
@@ -104,6 +104,14 @@ var Presets = []Preset{
 		HelpURL:      "https://platform.kimi.ai/console/api-keys",
 	},
 	{
+		Name:         "qwen",
+		Kind:         "openai",
+		BaseURL:      "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+		DefaultModel: "qwen-plus",
+		EnvKeys:      []string{"KPROMPT_QWEN_API_KEY", "DASHSCOPE_API_KEY", "QWEN_API_KEY"},
+		HelpURL:      "https://www.alibabacloud.com/help/en/model-studio/",
+	},
+	{
 		Name:         "openrouter",
 		Kind:         "openai",
 		BaseURL:      "https://openrouter.ai/api/v1",

--- a/internal/llm/presets_test.go
+++ b/internal/llm/presets_test.go
@@ -64,7 +64,7 @@ func TestLookupPresetCerebras(t *testing.T) {
 func TestSupportedNamesIncludesNewProviders(t *testing.T) {
 	s := SupportedNames()
 	wantNames := []string{"openai", "anthropic", "gemini", "groq",
-		"mistral", "deepseek", "moonshot", "ollama", "openrouter",
+		"mistral", "deepseek", "moonshot", "qwen", "ollama", "openrouter",
 		"together", "xai", "cerebras", "azure", "fireworks"}
 	for _, want := range wantNames {
 		if !contains(s, want) {
@@ -135,6 +135,25 @@ func TestLookupPresetFireworks(t *testing.T) {
 	}
 	if len(p.EnvKeys) != 2 || p.EnvKeys[0] != "KPROMPT_FIREWORKS_API_KEY" || p.EnvKeys[1] != "FIREWORKS_API_KEY" {
 		t.Fatalf("cerebras env keys = %v", p.EnvKeys)
+	}
+}
+
+func TestLookupPresetQwen(t *testing.T) {
+	p, ok := LookupPreset("qwen")
+	if !ok {
+		t.Fatal("qwen preset not found")
+	}
+	if p.Kind != "openai" {
+		t.Fatalf("qwen kind = %q, want openai", p.Kind)
+	}
+	if p.BaseURL != "https://dashscope-intl.aliyuncs.com/compatible-mode/v1" {
+		t.Fatalf("qwen base URL = %q", p.BaseURL)
+	}
+	if p.DefaultModel != "qwen-plus" {
+		t.Fatalf("qwen default model = %q, want qwen-plus", p.DefaultModel)
+	}
+	if len(p.EnvKeys) != 3 || p.EnvKeys[0] != "KPROMPT_QWEN_API_KEY" || p.EnvKeys[1] != "DASHSCOPE_API_KEY" || p.EnvKeys[2] != "QWEN_API_KEY" {
+		t.Fatalf("qwen env keys = %v", p.EnvKeys)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `qwen` as a named OpenAI-compatible preset for Alibaba Cloud DashScope (P-005), complementing Moonshot for China/APAC BYOK coverage. Reuses the existing `openai.go` adapter — no new adapter code.

Closes #56

## Changes

- `internal/llm/presets.go`: add `qwen` preset (DashScope intl base URL, `qwen-plus` default model, env keys `KPROMPT_QWEN_API_KEY`/`DASHSCOPE_API_KEY`/`QWEN_API_KEY`)
- `internal/llm/presets_test.go`: add `TestLookupPresetQwen`, include `qwen` in `SupportedNames` assertion
- `cmd/kprompt/main.go`: add `qwen` to `--provider` help string
- `docs/providers.md`: table row, regional note (intl vs. CN-mainland endpoint + `KPROMPT_OPENAI_BASE_URL` override), usage example
- `README.md`: add `qwen` to `--provider` flags table

## Test plan

- [x] `go test ./...` (CLI)
- [ ] Manual: not run — no DashScope API key available; `qwen` reuses the already-tested `openai.go` adapter
- [x] No secrets, kubeconfigs, or API keys in the diff