### PR TITLE
feat(fanout): allow istio and gitops read fan-out across contexts

### DIFF
--- a/docs/multi-cluster.md
+++ b/docs/multi-cluster.md
@@ -32,11 +32,14 @@ kprompt --contexts staging,prod "list deployments"
 kprompt "list pods across staging and prod"
 kprompt --contexts staging,prod "optimize my cluster"
 kprompt --contexts staging,prod "show service graph" -n shop
+kprompt --contexts staging,prod "show virtualservice traffic for payments"
+kprompt --contexts staging,prod "gitops sync status"
 ```
 
 Supported today: get/list, explain, investigate, why, timeline, impact, audit,
 cleanup, search, score, architecture, learn, drift, logs, describe, optimize,
-roast, graph. Unreachable contexts degrade; others still return.
+roast, graph, istio, gitops (status/health only — see below). Unreachable
+contexts degrade; others still return.
 
 JSON kind: `MultiContextResult` with per-context `steps`, `cluster_context` on each step, and `fleetSummary` for optimize. Each step carries that context's own payload — e.g. one service graph per cluster under `steps[].result`.
 
@@ -47,7 +50,9 @@ query the Prometheus / OpenTelemetry endpoint you configured, not the kube
 context, so fanning out would repeat one identical query per context and label
 the same numbers as per-cluster findings. Point those at a per-cluster endpoint
 and run them with `--context` instead. Mutating intents never fan out silently —
-see below.
+see below. That includes gitops `sync`/`promote`/`rollback`: those require
+approval, so `--contexts` routes them through the same per-context mutate
+gating as `scale`/`delete` (below) — only `status`/`health` reads fan out.
 
 ## Mutate safety
 

--- a/internal/pipeline/fanout.go
+++ b/internal/pipeline/fanout.go
@@ -37,7 +37,7 @@ var readFanOutKinds = []intent.Kind{
 	intent.KindTimeline, intent.KindImpact, intent.KindAudit, intent.KindCleanup,
 	intent.KindSearch, intent.KindScore, intent.KindArchitecture, intent.KindLearn,
 	intent.KindDrift, intent.KindLogs, intent.KindDescribe, intent.KindOptimize,
-	intent.KindRoast, intent.KindGraph,
+	intent.KindRoast, intent.KindGraph, intent.KindIstio, intent.KindGitOps,
 }
 
 func supportsReadFanOut(kind intent.Kind) bool {

--- a/internal/pipeline/fanout_test.go
+++ b/internal/pipeline/fanout_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/kprompt/kprompt/internal/intent"
 	"github.com/kprompt/kprompt/internal/llm"
 	"github.com/kprompt/kprompt/internal/output"
+	"github.com/kprompt/kprompt/internal/planner"
+	"github.com/kprompt/kprompt/internal/safety"
 )
 
 func TestMultiContextRefusesSilentApprove(t *testing.T) {
@@ -203,7 +205,7 @@ func TestSupportsReadFanOut(t *testing.T) {
 		intent.KindGet, intent.KindExplain, intent.KindInvestigate, intent.KindWhy,
 		intent.KindTimeline, intent.KindImpact, intent.KindAudit, intent.KindCleanup,
 		intent.KindSearch, intent.KindScore, intent.KindArchitecture, intent.KindLearn, intent.KindDrift, intent.KindLogs, intent.KindDescribe, intent.KindOptimize,
-		intent.KindRoast, intent.KindGraph,
+		intent.KindRoast, intent.KindGraph, intent.KindIstio, intent.KindGitOps,
 	}
 	for _, k := range ok {
 		if !supportsReadFanOut(k) {
@@ -308,5 +310,95 @@ func TestMultiContextDeniesEndpointBackedRead(t *testing.T) {
 	}
 	if !strings.Contains(doc.Risk.Message, "performance") || !strings.Contains(doc.Risk.Message, "graph") {
 		t.Fatalf("deny message should name the rejected kind and the allowlist: %q", doc.Risk.Message)
+	}
+}
+
+// TestMultiContextIstioAndGitOpsReadsAllowed exercises the fan-out dispatch
+// layer directly (no real cluster needed): a read-only istio/gitops plan
+// must clear the supportsReadFanOut gate and reach fanOutSteps instead of
+// being denied as an unsupported kind (issue #159).
+func TestMultiContextIstioAndGitOpsReadsAllowed(t *testing.T) {
+	for _, in := range []intent.Intent{
+		{Kind: intent.KindIstio, Target: intent.Target{Kind: "VirtualService", Namespace: "default"}},
+		{Kind: intent.KindGitOps, Params: map[string]any{"action": "status"}, Target: intent.Target{Namespace: "default"}},
+	} {
+		plan, err := planner.Build(in)
+		if err != nil {
+			t.Fatalf("%s: build plan: %v", in.Kind, err)
+		}
+		if plan.RequiresApproval {
+			t.Fatalf("%s: expected a read-only status/health plan", in.Kind)
+		}
+		if !isReadOnly(plan) {
+			t.Fatalf("%s: expected isReadOnly", in.Kind)
+		}
+		if !supportsReadFanOut(plan.Intent.Kind) {
+			t.Fatalf("%s: expected supportsReadFanOut after #159", in.Kind)
+		}
+
+		var out bytes.Buffer
+		contexts := []string{"ctx-a", "ctx-b"}
+		err = runMultiContextReads(context.Background(), config.Resolved{
+			Prompt:   "n/a",
+			Contexts: contexts,
+			Output:   "json",
+		}, &out, Deps{}, nil, plan, safety.Result{}, contexts)
+		if err != nil {
+			t.Fatalf("%s: %v", in.Kind, err)
+		}
+
+		var doc output.MultiContextResult
+		if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+			t.Fatalf("%s: expected a MultiContextResult (not a single-kind denial): %v\n%s", in.Kind, err, out.String())
+		}
+		if doc.Kind != output.KindMultiContextResult {
+			t.Fatalf("%s: kind=%s", in.Kind, doc.Kind)
+		}
+		if len(doc.Steps) != len(contexts) {
+			t.Fatalf("%s: steps=%d", in.Kind, len(doc.Steps))
+		}
+		for _, step := range doc.Steps {
+			if strings.Contains(step.Risk.Message, "multi-context fan-out supports") {
+				t.Fatalf("%s: still denied as unsupported kind: %q", in.Kind, step.Risk.Message)
+			}
+		}
+	}
+}
+
+// TestMultiContextGitOpsMutateRefusesSilentApprove asserts that a gitops
+// sync/promote/rollback plan (RequiresApproval=true) never silently fans out
+// under plain --approve, exactly like every other mutating kind (issue #159).
+func TestMultiContextGitOpsMutateRefusesSilentApprove(t *testing.T) {
+	plan, err := planner.Build(intent.Intent{
+		Kind:   intent.KindGitOps,
+		Params: map[string]any{"action": "sync", "engine": "argocd"},
+		Target: intent.Target{Kind: "Application", Name: "payments", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.RequiresApproval {
+		t.Fatal("expected gitops sync to require approval")
+	}
+	if isReadOnly(plan) {
+		t.Fatal("gitops sync must not be treated as read-only")
+	}
+
+	var out bytes.Buffer
+	err = runMultiContextFanOut(context.Background(), config.Resolved{
+		Approve:  true,
+		Prompt:   "sync argocd application payments",
+		Contexts: []string{"ctx-a", "ctx-b"},
+		Output:   "json",
+	}, &out, Deps{}, nil, plan, safety.Result{}, []string{"ctx-a", "ctx-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc output.PlanResult
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("%v\n%s", err, out.String())
+	}
+	if !doc.Risk.Denied || !strings.Contains(doc.Risk.Message, "--approve") {
+		t.Fatalf("expected silent-approve refusal, got %+v", doc.Risk)
 	}
 }


### PR DESCRIPTION
## Summary

`istio` and `gitops` are already read-only (`isReadOnly`) but read fan-out rejected them — so fleet VirtualService / gitops sync-status compare needed one run per cluster.

Fixes #159.

## Changes

- `istio` and `gitops` added to the read fan-out allowlist (`fanout.go`)
- `gitops` mutate (`sync`/`promote`/`rollback`) is unaffected — `RequiresApproval: true` already routes it through the existing per-context mutate approval gate, so it still never fans out silently
- `docs/multi-cluster.md`: supported-list updated, mutate-gating note added for gitops

## Test plan

- [x] `go test ./...`
- [ ] Manual: not run
- [x] No secrets, kubeconfigs, or API keys in the diff

## AI Usage
- **Use:** yes
- **Model:** Claude Sonnet 5
- **Used for:** Allowlist change, fan-out and deny-path tests