### PR TITLE
feat: GitOps PR mode for audit harden (#51)

### DIFF
--- a/docs/gitops-pr.md
+++ b/docs/gitops-pr.md
@@ -48,6 +48,7 @@ local CLI path.
 | Kind | Behavior |
 |------|----------|
 | `deploy` | Commit rendered Deployment/Service YAML into the PR |
+| `patch` | Commits fixs (e.g. audit hardening) to the PR |
 | `install` / `upgrade` (Helm) | Re-run `helm template` / dry-run and commit full YAML |
 
 Scale, delete, rollback, live Flux/Argo **sync**, Argo Workflows, Tekton, KEDA,

--- a/internal/gitopspr/gitopspr.go
+++ b/internal/gitopspr/gitopspr.go
@@ -187,7 +187,7 @@ func FilesFromPlan(ctx context.Context, plan planner.ExecutionPlan, pathPrefix s
 		// ok
 	default:
 		return nil, fmt.Errorf(
-			"gitops PR mode MVP supports deploy / helm install / helm upgrade plans (got kind=%s). Scale, delete, and live GitOps sync still use cluster apply — omit --gitops for those",
+			"gitops PR mode MVP supports deploy / helm install / helm upgrade plans / patch (got kind=%s). Scale, delete, and live GitOps sync still use cluster apply — omit --gitops for those",
 			plan.Intent.Kind,
 		)
 	}

--- a/internal/gitopspr/gitopspr_test.go
+++ b/internal/gitopspr/gitopspr_test.go
@@ -55,11 +55,53 @@ func TestFilesFromPlanDeploy(t *testing.T) {
 	}
 }
 
+func TestFilesFromPlanPatch(t *testing.T) {
+	auditHardenPlan := planner.ExecutionPlan{
+		Intent:           intent.Intent{Kind: intent.KindPatch},
+		Summary:          "Harden 1 workload(s): remove privilege grants",
+		RequiresApproval: true,
+		Actions: []planner.Action{{
+			Op:       planner.OpUpdate,
+			Object:   planner.ObjectRef{Kind: "Deployment", Name: "bad", Namespace: "payments"},
+			Manifest: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: bad\n  namespace: payments\n",
+		}},
+	}
+	files, err := FilesFromPlan(context.Background(), auditHardenPlan, "clusters/dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0].Path != "clusters/dev/deployment-bad.yaml" {
+		t.Fatalf("%+v", files)
+	}
+}
+
+func TestTruncatedpreview(t *testing.T) {
+	auditHardenPlan := planner.ExecutionPlan{
+		Intent:  intent.Intent{Kind: intent.KindPatch},
+		Summary: "Harden 1 workload(s): remove privilege grants",
+		Actions: []planner.Action{{
+			Op:       planner.OpUpdate,
+			Object:   planner.ObjectRef{APIVersion: "apps/v1", Kind: "StatefulSet", Name: "db", Namespace: "payments"},
+			Manifest: "apiVersion: apps/v1\nkind: StatefulSet\nmetadata:\n  name: db\n  namespace: payments \n…(preview truncated)",
+		}},
+	}
+	files, err := FilesFromPlan(context.Background(), auditHardenPlan, "clusters/dev")
+	if err == nil {
+		t.Fatal("expected truncated preview error got no got error")
+	}
+	if !strings.Contains(err.Error(), "manifest preview is truncated") {
+		t.Errorf("expected truncated preview error got %v", err)
+	}
+	if files != nil {
+		t.Errorf("expected files to be empty")
+	}
+}
+
 func TestFilesFromPlanRejectsScale(t *testing.T) {
 	plan := planner.ExecutionPlan{
 		Intent: intent.Intent{Kind: intent.KindScale},
 		Actions: []planner.Action{{
-			Op: planner.OpScale,
+			Op:     planner.OpScale,
 			Object: planner.ObjectRef{Kind: "Deployment", Name: "api"},
 		}},
 	}


### PR DESCRIPTION
## Summary

Fixes #51

Updating docs, error messages, and units to match the relevant code for `KindPatch` in GitOps PR mode.

## Changes

- Fixed the error message in `internal/gitopspr/gitopspr.go` to show that `intent.KindPatch` is allowed.
- Updated `docs/gitops-pr.md` to show that patch is a relevant kind.
- Added an `intent.KindPatch` test for `FilesFromPlan`, with input similar to the harden audit plan.
- Added a test for checking rejected truncated previews.
- Not included (Optional stretch: scale as strategic merge patch YAML in repo).

## Test plan

- `go test ./internal/gitopspr/` is green.

Please let me know if you want any changes. Thanks!