### PR TITLE
chore: run kind e2e suite in CI #47

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,17 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_full_e2e_tests:
+        description: 'Run full e2e test suite or default smoke test?'
+        required: true
+        type: choice
+        options:
+          - smoke
+          - full
+        default: smoke
+  
 
 jobs:
   test:
@@ -15,10 +26,31 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+
       - name: Test with coverage
         run: go test -json -coverprofile=coverage.out -covermode=atomic ./... > report.json || true
+
       - name: Build
         run: go build -o bin/kprompt ./cmd/kprompt
+
+      - name: Setup Kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'v1.36.4'
+      - name: Install KinD 
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+      
+      - name: Smokes Tests (subset of e2e tests)
+        if: github.event_name != 'workflow_dispatch' || inputs.run_full_e2e_tests == 'smoke'
+        run: go test -tags=e2e ./test/e2e/ -run 'TestGenericReadMatrixOnKind|TestDeployRedisOnKind|TestAgentWatchPodsEvents' -count=1 -v -timeout 10m
+
+      - name: Full End to End Tests
+        if: inputs.run_full_e2e_tests == 'full'
+        run: go test -tags=e2e ./test/e2e/ -count=1 -v -timeout 10m
+    
       # Requires Automatic Analysis disabled on SonarCloud (Project → Administration → Analysis Method).
       # CI-based analysis cannot run while Autoscan is enabled.
       # Skipped for forks and Dependabot PRs: GitHub does not expose SONAR_TOKEN

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -86,3 +86,14 @@ GitHub Actions on `kprompt/kprompt` can upload a **stub** PlanResult to Team aft
 Without the secret, CI still passes and skips the upload. With it: Audit `reported`, app `/ci` artifact, and (when App JWT + Checks write are configured) a Check Run named `kprompt` via optional `head_sha`.
 
 See also: [GitOps PR mode](./gitops-pr.md) (CLI laptop lane; separate from Team org connect).
+
+
+## Tests
+
+Unit tests:
+`go test -json -coverprofile=coverage.out -covermode=atomic ./... > report.json`
+Runs to build report of units tests reuslts allowing PlanResult to be built.
+
+CI Smoke test:
+On a pull request tests `TestGenericReadMatrixOnKind|TestDeployRedisOnKind|TestAgentWatchPodsEvents`
+automatically run. Full e2e can be ran via workflow_dispatch.

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -19,6 +19,10 @@ Optional cleanup:
 kind delete cluster --name kprompt-e2e
 ```
 
+CI Smoke test:
+On a pull request tests `TestGenericReadMatrixOnKind|TestDeployRedisOnKind|TestAgentWatchPodsEvents`
+automatically run. Full e2e can be ran via workflow_dispatch.
+
 Notes:
 
 - Uses stub LLM providers so no real API key is required.


### PR DESCRIPTION
## Summary
Fixes #47
e2e test did not exist in CI, e2e only ran manually locally.

## Changes

- Added in default smoke with `TestGenericReadMatrixOnKind|TestDeployRedisOnKind|TestAgentWatchPodsEvents` e2e tests
- Added in a full e2e test suite option via `workflow_dispatch` 
- Documented the job in docs/e2e.md and in /docs/ci.md
- Full and smoke test are under a time budget

Note: no fail message added, as the test are already skipped by requireKind if kind and kubectl can't be found.

I am happy to make any changes if you want. 
