### PR TITLE
feat(llm): add Hetzner Inference as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ kprompt is **bring-your-own-key**. Point it at local Ollama for `$0` inference, 
 | **Ollama** (`$0`, local) | **OpenAI** | **Anthropic** | **Gemini** |
 | **Groq** | **xAI** | **Cerebras** | **Mistral** |
 | **DeepSeek** | **Moonshot** | **OpenRouter** | **Together** |
-| **OpenAI-compatible** (any base URL) | | | |
+| **Hetzner** | **OpenAI-compatible** (any base URL) | | |
 
 ### Kubernetes & day-2
 
@@ -414,7 +414,7 @@ The `kp_…` token is stored only in `credentials.yaml` (0600), never in `config
 | `--wait` | After apply, wait for Deployment / StatefulSet / DaemonSet rollout, then verify |
 | `--timeout` | Timeout for `--wait` (default `5m`) |
 | `--output` / `-o` | `text` (default) or `json` (CI PlanResult) |
-| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `qwen`, `openrouter`, `together`, `fireworks`, `ollama`, `lmstudio`, `azure`, `openai-compatible` |
+| `--provider` | `openai`, `anthropic`, `gemini`, `groq`, `xai`, `cerebras`, `mistral`, `deepseek`, `moonshot`, `qwen`, `openrouter`, `together`, `fireworks`, `hetzner`, `ollama`, `lmstudio`, `azure`, `openai-compatible` |
 | `--model` | Model id |
 | `--context` | kubeconfig context |
 | `--contexts` | Comma-separated contexts for read fan-out / per-context mutate |

--- a/cmd/kprompt/main.go
+++ b/cmd/kprompt/main.go
@@ -109,7 +109,7 @@ Bare kprompt (no args) prints a readiness coach. Full help: kprompt --help · kp
 	root.PersistentFlags().BoolVar(&approveEachContext, "approve-each-context", false, "apply a mutating plan to every --contexts entry (explicit; not implied by --approve)")
 	root.PersistentFlags().BoolVar(&waitFlag, "wait", false, "after apply, wait for Deployment/StatefulSet/DaemonSet rollout to complete")
 	root.PersistentFlags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for --wait (default 5m)")
-	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|qwen|openrouter|together|fireworks|ollama|lmstudio|azure|openai-compatible)")
+	root.PersistentFlags().StringVar(&provider, "provider", "", "LLM provider (openai|anthropic|gemini|groq|xai|cerebras|mistral|deepseek|moonshot|qwen|openrouter|together|fireworks|hetzner|ollama|lmstudio|azure|openai-compatible)")
 	root.PersistentFlags().StringVar(&model, "model", "", "LLM model id")
 	root.PersistentFlags().StringVar(&kubeCtx, "context", "", "kubeconfig context")
 	root.PersistentFlags().StringVar(&kubeCtxs, "contexts", "", "comma-separated contexts for read fan-out / per-context mutate (aliases ok)")

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -27,6 +27,7 @@ Optional Team `kp_…` tokens (`kprompt login`) are for org policy/audit — not
 | OpenRouter | `openrouter` | `KPROMPT_OPENROUTER_API_KEY` / `OPENROUTER_API_KEY` | `openai/gpt-4o-mini` | OpenAI-compatible |
 | Together | `together` | `KPROMPT_TOGETHER_API_KEY` / `TOGETHER_API_KEY` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | OpenAI-compatible |
 | Fireworks | `fireworks` | `KPROMPT_FIREWORKS_API_KEY` / `FIREWORKS_API_KEY` | `accounts/fireworks/models/llama-v3p3-70b-instruct` | OpenAI-compatible |
+| Hetzner Inference | `hetzner` | `KPROMPT_HETZNER_API_KEY` / `HETZNER_API_KEY` | `Qwen/Qwen3.6-35B-A3B-FP8` | OpenAI-compatible; **experimental**, free while in beta, no SLA |
 | LM Studio (local) | `lmstudio` | none required | `local-model` | **$0** — `http://127.0.0.1:1234/v1`; LM Studio must be running with a model loaded, and `--model` must match that model's name |
 | Generic OpenAI-compat | `openai-compatible` | `KPROMPT_OPENAI_API_KEY` | — | **Requires** `base_url` |
 | Azure OpenAI | `azure` | `KPROMPT_AZURE_API_KEY` / `AZURE_OPENAI_API_KEY` / `KPROMPT_OPENAI_API_KEY` | `gpt-4o` | OpenAI-compatible; **Requires** `base_url` (resource URL). `--model` is your **deployment name**, not an OpenAI model id |
@@ -131,6 +132,10 @@ kprompt --provider azure --model my-gpt4o-deploy "list services"
 export KPROMPT_FIREWORKS_API_KEY=...
 kprompt init --provider fireworks
 kprompt "list deployments"
+
+# Hetzner Inference (experimental, free while in beta)
+export KPROMPT_HETZNER_API_KEY=...
+kprompt --provider hetzner "list pods"
 ```
 
 On Azure, `--model` carries the **deployment name** you chose in the portal — not an OpenAI
@@ -139,6 +144,8 @@ model id. They match only if you named the deployment after the model. The prese
 deployment, or requests fail with a deployment-not-found error from Azure.
 
 Fireworks models are account scoped. Public models, model name: accounts/fireworks/models/{model-name}. 
+
+Hetzner's Inference API is an **experimental** platform: free while in beta, no SLA/backup guarantees, and only a limited model selection. See [experiments.hetzner.com/docs/inference](https://experiments.hetzner.com/docs/inference).
 
 
 ## Config file (`~/.kprompt/config.yaml`)

--- a/internal/llm/presets.go
+++ b/internal/llm/presets.go
@@ -153,6 +153,14 @@ var Presets = []Preset{
 		EnvKeys:      []string{"KPROMPT_FIREWORKS_API_KEY", "FIREWORKS_API_KEY"},
 		HelpURL:      "https://fireworks.ai/account/api-keys",
 	},
+	{
+		Name:         "hetzner",
+		Kind:         "openai",
+		BaseURL:      "https://inference.hetzner.com/api/v1",
+		DefaultModel: "Qwen/Qwen3.6-35B-A3B-FP8",
+		EnvKeys:      []string{"KPROMPT_HETZNER_API_KEY", "HETZNER_API_KEY"},
+		HelpURL:      "https://experiments.hetzner.com/docs/inference",
+	},
 }
 
 // LookupPreset finds a preset by name (case-insensitive).

--- a/internal/llm/presets_test.go
+++ b/internal/llm/presets_test.go
@@ -65,7 +65,8 @@ func TestSupportedNamesIncludesNewProviders(t *testing.T) {
 	s := SupportedNames()
 	wantNames := []string{"openai", "anthropic", "gemini", "groq",
 		"mistral", "deepseek", "moonshot", "qwen", "ollama", "openrouter",
-		"together", "xai", "cerebras", "azure", "fireworks", "lmstudio"}
+		"together", "xai", "cerebras", "azure", "fireworks", "lmstudio",
+		"hetzner"}
 	for _, want := range wantNames {
 		if !contains(s, want) {
 			t.Fatalf("%q missing from %s", want, s)
@@ -173,6 +174,25 @@ func TestLookupPresetQwen(t *testing.T) {
 	}
 	if len(p.EnvKeys) != 3 || p.EnvKeys[0] != "KPROMPT_QWEN_API_KEY" || p.EnvKeys[1] != "DASHSCOPE_API_KEY" || p.EnvKeys[2] != "QWEN_API_KEY" {
 		t.Fatalf("qwen env keys = %v", p.EnvKeys)
+	}
+}
+
+func TestLookupPresetHetzner(t *testing.T) {
+	p, ok := LookupPreset("hetzner")
+	if !ok {
+		t.Fatal("hetzner preset not found")
+	}
+	if p.Kind != "openai" {
+		t.Fatalf("hetzner kind = %q, want openai", p.Kind)
+	}
+	if p.BaseURL != "https://inference.hetzner.com/api/v1" {
+		t.Fatalf("hetzner base URL = %q", p.BaseURL)
+	}
+	if p.DefaultModel != "Qwen/Qwen3.6-35B-A3B-FP8" {
+		t.Fatalf("hetzner default model = %q, want Qwen/Qwen3.6-35B-A3B-FP8", p.DefaultModel)
+	}
+	if len(p.EnvKeys) != 2 || p.EnvKeys[0] != "KPROMPT_HETZNER_API_KEY" || p.EnvKeys[1] != "HETZNER_API_KEY" {
+		t.Fatalf("hetzner env keys = %v", p.EnvKeys)
 	}
 }
 


### PR DESCRIPTION
Adds the hetzner preset (base URL https://inference.hetzner.com/api/v1, default model Qwen/Qwen3.6-35B-A3B-FP8), env keys KPROMPT_HETZNER_API_KEY / HETZNER_API_KEY, docs, README, and --provider flag help. Notes it as experimental/free-while-in-beta per Hetzner's Experiments platform terms.

## Summary

Adds [Hetzner's Inference API](https://experiments.hetzner.com/docs/inference) as a new LLM provider option. It's an OpenAI-compatible endpoint, so it reuses the existing `OpenAI` client (Bearer auth) via `Kind: "openai"` — no new provider adapter code needed. Documented as experimental/free-while-in-beta per Hetzner's Experiments platform terms (no SLA, may change or be discontinued).

## Changes

- `internal/llm/presets.go`: new `hetzner` preset — base URL `https://inference.hetzner.com/api/v1`, default model `Qwen/Qwen3.6-35B-A3B-FP8`, env keys `KPROMPT_HETZNER_API_KEY` / `HETZNER_API_KEY`.
- `internal/llm/presets_test.go`: `TestLookupPresetHetzner` + added `hetzner` to `TestSupportedNamesIncludesNewProviders`.
- `docs/providers.md`: provider table row, curl/env example, and experimental-status note.
- `README.md`: added Hetzner to the LLM providers grid and `--provider` flag reference.
- `cmd/kprompt/main.go`: `--provider` flag help text lists `hetzner`.

## Test plan

- [x] `go test ./...` (CLI) and/or website checks as applicable
- [ ] Manual: relevant `kprompt "..."` prompts / install path verified
- [x] No secrets, kubeconfigs, or API keys in the diff