### PR TITLE
ci(deps): bump github/codeql-action to v4.37.9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: go
       # Autobuild fails to extract this module ("Extraction failed for all
@@ -30,6 +30,6 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:go"


### PR DESCRIPTION
## Summary
- Pin `codeql-action/init` and `analyze` to **v4.37.9** (`cdf488f…`) in one change
- Supersedes the failed/outdated Dependabot PRs #178 and #179 (4.37.7; Analyze was red; 4.37.8+ already shipped)

Also created missing `ci` / `dependencies` labels so future Dependabot PRs can label correctly.

## Test plan
- [ ] CodeQL **Analyze (go)** green on this PR
- [ ] Close #178 and #179 as superseded

Made with [Cursor](https://cursor.com)