### PR TITLE
ci: kind e2e smoke job (closes #47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_full_e2e_tests:
+        description: "Run full e2e suite (default: smoke subset)"
+        required: true
+        type: choice
+        options:
+          - smoke
+          - full
+        default: smoke
 
 jobs:
   test:
@@ -29,6 +39,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  # Kind + kubectl e2e smoke (issue #47). Separate from unit/Sonar so PR unit
+  # feedback stays fast. Full suite via workflow_dispatch input "full".
+  e2e:
+    needs: test
+    runs-on: ubuntu-latest
+    # Dependabot PRs do not need a live cluster; keep Actions minutes for product PRs.
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+        with:
+          version: "v1.33.1"
+      - name: Install kind
+        run: |
+          set -euo pipefail
+          KIND_VERSION=v0.29.0
+          curl -fsSL -o ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          echo "c72eda46430f065fb45c5f70e7c957cc9209402ef309294821978677c8fb3284  kind" | sha256sum -c -
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+          kubectl version --client
+      - name: E2E smoke
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_full_e2e_tests == 'smoke' }}
+        run: >
+          go test -tags=e2e ./test/e2e/
+          -run 'TestGenericReadMatrixOnKind|TestDeployRedisOnKind|TestAgentWatchPodsEvents'
+          -count=1 -v -timeout 10m
+      - name: E2E full
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_full_e2e_tests == 'full' }}
+        run: go test -tags=e2e ./test/e2e/ -count=1 -v -timeout 15m
 
   # Team SCM demo (A-065 / A-069): stub PlanResult upload when org token is set.
   # Never applies to a cluster. Skips cleanly without KPROMPT_ORG_TOKEN.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -72,6 +72,10 @@ echo "$json" | jq -e '(.blastRadius.namespaces // []) | length <= 1'
 echo "$json" | jq -e '.verify.status == "ok"'
 ```
 
+## Kind e2e in Actions
+
+Workflow [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) job **`e2e`**: installs kind (checksum-verified) and kubectl (SHA-pinned action), then runs a smoke subset on every PR/push to `main`. Full suite: **Actions → ci → Run workflow → `full`**. Details: [e2e.md](./e2e.md).
+
 ## Team org ingest (this repo’s Actions)
 
 GitHub Actions on `kprompt/kprompt` can upload a **stub** PlanResult to Team after tests pass (optional job `report-plan` in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). This does **not** apply anything to a cluster.

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -13,6 +13,18 @@ Optional focused generic-read matrix (T-051):
 go test -tags=e2e ./test/e2e/ -run 'TestGenericReadMatrixOnKind|TestListDeploymentsOnKind' -count=1 -v -timeout 15m
 ```
 
+## GitHub Actions (CI)
+
+`.github/workflows/ci.yml` runs a separate **`e2e`** job (after unit `test`) with kind + SHA-pinned `azure/setup-kubectl`:
+
+| Trigger | Suite |
+|---------|--------|
+| `push` / `pull_request` | **Smoke** — `TestGenericReadMatrixOnKind`, `TestDeployRedisOnKind`, `TestAgentWatchPodsEvents` (10m) |
+| `workflow_dispatch` → `full` | Full `./test/e2e/` (15m) |
+| Dependabot PRs | Job skipped |
+
+No cluster secrets required (stub LLM). Fork PRs can run smoke like other PRs.
+
 Optional cleanup:
 
 ```bash


### PR DESCRIPTION
## Summary
- Separate **`e2e`** job in `.github/workflows/ci.yml` (after unit `test`) so Sonar/unit stay fast
- Smoke on PR/push: `TestGenericReadMatrixOnKind|TestDeployRedisOnKind|TestAgentWatchPodsEvents` (10m)
- Full suite via `workflow_dispatch` input `full` (15m); Dependabot skips e2e
- SHA-pin `azure/setup-kubectl@v4.0.1`; checksum-verify kind `v0.29.0`
- Docs: [e2e.md](docs/e2e.md), [ci.md](docs/ci.md)

Closes #47.

Credit: approach from @JoshPigott in #180 — this PR addresses review feedback (dedicated job + pinned action).

## Test plan
- [ ] CI `e2e` job green on this PR
- [ ] Confirm Dependabot PRs still skip e2e when that path runs
- [ ] Optional: Actions → ci → Run workflow → `full` after merge


Made with [Cursor](https://cursor.com)