### PR TITLE
feat(security): finish SEC-007 checklist (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to kprompt are documented here. Versions follow [GitHub Rele
 
 ### Security
 
-- **SEC-007 follow-up** — operator endpoint hardening guide + `kprompt doctor` advisory for Observe agent NetworkPolicy / `hostNetwork` (#118)
+- **SEC-007 follow-up** — operator endpoint hardening guide + doctor advisories for workload NetworkPolicy / `hostNetwork` and private-range endpoint URLs; Helm `values.schema.json` + coordinator/operator NetworkPolicy baselines (#118)
 
 ## [v0.12.0](https://github.com/kprompt/kprompt/releases/tag/v0.12.0) — 2026-08-29
 

--- a/charts/kprompt-agent/Chart.yaml
+++ b/charts/kprompt-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kprompt-agent
 description: Namespace-scoped kprompt Observe agent (watch → correlate → analyze → notify). Never mutates the cluster.
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: "0.12.0"
 home: https://kprompt.ai
 sources:

--- a/charts/kprompt-agent/README.md
+++ b/charts/kprompt-agent/README.md
@@ -111,6 +111,7 @@ NetworkPolicy controls in this chart:
 - `networkPolicy.allowDNS`: allow DNS to cluster DNS
 - `networkPolicy.allowKubeApi` + `networkPolicy.kubeAPIServerCIDRs`: allow kube-apiserver egress via explicit CIDRs
 - `networkPolicy.llmCIDRs`, `networkPolicy.observabilityCIDRs`, `networkPolicy.webhookCIDRs`: explicit endpoint allowlists
+- `values.schema.json` validates the `networkPolicy` block when you `helm install` / `helm lint`
 
 Use these settings with your cluster CNI policy model (Calico/Cilium/etc.) and keep allowlists narrow.
 

--- a/charts/kprompt-agent/values.schema.json
+++ b/charts/kprompt-agent/values.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Opt-in egress default-deny. Do not enable until CIDRs match your topology."
+        },
+        "allowDNS": { "type": "boolean" },
+        "allowKubeApi": { "type": "boolean" },
+        "kubeAPIServerCIDRs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "CIDRs for kube-apiserver (required when allowKubeApi and enabled)."
+        },
+        "llmCIDRs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "llmPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "llmExtraPorts": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+        },
+        "observabilityCIDRs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "observabilityExtraPorts": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+        },
+        "webhookCIDRs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "webhookExtraPorts": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+        },
+        "extraEgress": {
+          "type": "array",
+          "description": "Raw NetworkPolicyEgressRule objects appended to egress."
+        }
+      }
+    }
+  }
+}

--- a/charts/kprompt-coordinator/Chart.yaml
+++ b/charts/kprompt-coordinator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kprompt-coordinator
 description: Thin Coordinator HTTP fan-in for kprompt Namespace Agents (AG-037; no mutate)
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.12.0"

--- a/charts/kprompt-coordinator/README.md
+++ b/charts/kprompt-coordinator/README.md
@@ -68,5 +68,6 @@ Ops checklist: [docs/agent-ops.md](../../docs/agent-ops.md#worker-isolation-ag-0
 | `probe.enabled` | `false` | Passes `--probe-kube --in-cluster` |
 | `knowledge.enabled` | `true` | Persists the Shared Knowledge handoff ring in a ConfigMap and enables the durable knowledge backend |
 | `rbac.probeNamespaces` | `[]` | RoleBindings for AG-050 probe |
+| `networkPolicy.enabled` | `false` | Opt-in egress default-deny; set `kubeAPIServerCIDRs` first |
 
-See [docs/namespace-agent.md](../../docs/namespace-agent.md) · [docs/agent-ops.md](../../docs/agent-ops.md).
+See [docs/namespace-agent.md](../../docs/namespace-agent.md) · [docs/agent-ops.md](../../docs/agent-ops.md) · [operator-endpoint-hardening.md](../../docs/security/operator-endpoint-hardening.md) (SEC-007).

--- a/charts/kprompt-coordinator/templates/network-policy.yaml
+++ b/charts/kprompt-coordinator/templates/network-policy.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kprompt-coordinator.fullname" . }}-egress
+  labels:
+    {{- include "kprompt-coordinator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kprompt-coordinator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+  egress:
+    {{- if .Values.networkPolicy.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+
+    {{- if and .Values.networkPolicy.allowKubeApi (gt (len .Values.networkPolicy.kubeAPIServerCIDRs) 0) }}
+    - to:
+        {{- range .Values.networkPolicy.kubeAPIServerCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    {{- end }}
+
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- toYaml .Values.networkPolicy.extraEgress | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/kprompt-coordinator/values.schema.json
+++ b/charts/kprompt-coordinator/values.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Opt-in egress default-deny. Do not enable until kubeAPIServerCIDRs match your topology."
+        },
+        "allowDNS": { "type": "boolean" },
+        "allowKubeApi": { "type": "boolean" },
+        "kubeAPIServerCIDRs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "extraEgress": {
+          "type": "array",
+          "description": "Raw NetworkPolicyEgressRule objects appended to egress."
+        }
+      }
+    }
+  }
+}

--- a/charts/kprompt-coordinator/values.yaml
+++ b/charts/kprompt-coordinator/values.yaml
@@ -49,3 +49,14 @@ resources:
     memory: 128Mi
 
 replicaCount: 1
+
+networkPolicy:
+  # WARNING: Do not enable until kubeAPIServerCIDRs match your topology.
+  # Hardening guide: docs/security/operator-endpoint-hardening.md (SEC-007).
+  enabled: false
+  allowDNS: true
+  allowKubeApi: true
+  # Example: ["10.96.0.1/32"]
+  kubeAPIServerCIDRs: []
+  # Raw additional egress rules if needed.
+  extraEgress: []

--- a/charts/kprompt-operator/Chart.yaml
+++ b/charts/kprompt-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kprompt-operator
 description: Reconciles KpromptAgent CRs into namespace-scoped Observe agent Deployments (AG-014).
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: "0.12.0"

--- a/charts/kprompt-operator/README.md
+++ b/charts/kprompt-operator/README.md
@@ -8,6 +8,10 @@ Reconciles [`KpromptAgent`](../../deploy/crd/kprompt.ai_kpromptagents.yaml) CRs 
 
 Prefer the manual [`kprompt-agent`](../kprompt-agent) chart when you do not want a cluster-scoped operator SA.
 
+## NetworkPolicy (SEC-007)
+
+Opt-in egress default-deny via `networkPolicy.enabled` (default `false`). Set `networkPolicy.kubeAPIServerCIDRs` before enabling. Guide: [`docs/security/operator-endpoint-hardening.md`](../../docs/security/operator-endpoint-hardening.md).
+
 ## Install
 
 ```bash

--- a/charts/kprompt-operator/templates/network-policy.yaml
+++ b/charts/kprompt-operator/templates/network-policy.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kprompt-operator.fullname" . }}-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kprompt-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kprompt-operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    {{- if .Values.networkPolicy.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+
+    {{- if and .Values.networkPolicy.allowKubeApi (gt (len .Values.networkPolicy.kubeAPIServerCIDRs) 0) }}
+    - to:
+        {{- range .Values.networkPolicy.kubeAPIServerCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    {{- end }}
+
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- toYaml .Values.networkPolicy.extraEgress | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/kprompt-operator/values.schema.json
+++ b/charts/kprompt-operator/values.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Opt-in egress default-deny. Do not enable until kubeAPIServerCIDRs match your topology."
+        },
+        "allowDNS": { "type": "boolean" },
+        "allowKubeApi": { "type": "boolean" },
+        "kubeAPIServerCIDRs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "extraEgress": {
+          "type": "array",
+          "description": "Raw NetworkPolicyEgressRule objects appended to egress."
+        }
+      }
+    }
+  }
+}

--- a/charts/kprompt-operator/values.yaml
+++ b/charts/kprompt-operator/values.yaml
@@ -37,3 +37,14 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+networkPolicy:
+  # WARNING: Do not enable until kubeAPIServerCIDRs match your topology.
+  # Hardening guide: docs/security/operator-endpoint-hardening.md (SEC-007).
+  enabled: false
+  allowDNS: true
+  allowKubeApi: true
+  # Example: ["10.96.0.1/32"]
+  kubeAPIServerCIDRs: []
+  # Raw additional egress rules if needed.
+  extraEgress: []

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -17,7 +17,10 @@ If no provider is configured, the LLM check fails with a hint to run `kprompt in
 - Kubernetes access for the selected context
 - Optional integrations such as Helm and configured backends
 - Optional Team enrollment, cached policy, pulled provider keys, and learned profile
-- **Observe agent egress posture** (advisory): warns if agent pods lack an egress NetworkPolicy, or use `hostNetwork` — see [operator-endpoint-hardening.md](./security/operator-endpoint-hardening.md) (SEC-007)
+- **Observe / coordinator / operator egress posture** (advisory): warns if those pods lack an egress NetworkPolicy, or use `hostNetwork`
+- **Operator endpoint URLs** (advisory): warns if configured `base_url` / Prometheus / Grafana / OTel endpoints resolve to RFC-1918, link-local, or loopback (Decision A — no hard block)
+
+See [operator-endpoint-hardening.md](./security/operator-endpoint-hardening.md) (SEC-007).
 
 Required failures make the command exit with status `1`.
 

--- a/docs/security/operator-endpoint-hardening.md
+++ b/docs/security/operator-endpoint-hardening.md
@@ -20,15 +20,14 @@ Related product docs: [reality-anchors.md](../reality-anchors.md) · agent chart
 
 ## Chart baseline (opt-in)
 
-`charts/kprompt-agent` ships an **opt-in** egress NetworkPolicy (`networkPolicy.enabled`, default `false`):
+`charts/kprompt-agent`, `charts/kprompt-coordinator`, and `charts/kprompt-operator` each ship an **opt-in** egress NetworkPolicy (`networkPolicy.enabled`, default `false`):
 
 - Policy type: **Egress** default-deny once enabled
-- Explicit allows (when configured): DNS, kube-apiserver CIDRs, LLM / observability / webhook CIDRs, `extraEgress`
+- Explicit allows (when configured): DNS, kube-apiserver CIDRs; the agent chart also supports LLM / observability / webhook CIDRs + `extraEgress`
+- Helm **`values.schema.json`** validates the `networkPolicy` block
 - **Strongly recommended for production**, but only after CIDRs match your topology
 
-> Do **not** set `networkPolicy.enabled=true` with empty `kubeAPIServerCIDRs` / `llmCIDRs`. The pod will lose API and LLM egress.
-
-Coordinator / operator charts do not yet ship the same template; use this guide’s example manifests or CNI policy until they do.
+> Do **not** set `networkPolicy.enabled=true` with empty `kubeAPIServerCIDRs` (and for the agent, empty `llmCIDRs` when you need an LLM). The pod will lose API and/or LLM egress.
 
 ---
 
@@ -130,10 +129,12 @@ NetworkPolicy on IP blocks does not stop a DNS name from resolving to an unexpec
 
 ## Doctor advisory
 
-`kprompt doctor` emits a **WARN** (non-fatal) when it finds Observe agent pods and:
+`kprompt doctor` emits **WARN** (non-fatal) when:
 
-- no selecting **egress** NetworkPolicy, and/or
-- any agent pod with **`hostNetwork: true`**
+- it finds agent / coordinator / operator pods and
+  - no selecting **egress** NetworkPolicy, and/or
+  - any of those pods with **`hostNetwork: true`**
+- configured operator endpoints (`base_url`, `tools.prometheus.url`, `tools.grafana.url`, `tools.otel.endpoint`) resolve to **RFC-1918 / ULA / link-local / loopback** (or cannot be resolved)
 
 ```bash
 kprompt doctor

--- a/internal/doctor/agent_egress.go
+++ b/internal/doctor/agent_egress.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kprompt/kprompt/internal/cluster"
 )
 
-const agentAppNameLabel = "app.kubernetes.io/name=kprompt-agent"
+const kpromptWorkloadLabelSelector = "app.kubernetes.io/name in (kprompt-agent,kprompt-coordinator,kprompt-operator)"
 
 // AgentEgressSummary is the cluster posture used by the NetworkPolicy doctor check.
 type AgentEgressSummary struct {
@@ -24,7 +24,7 @@ type AgentEgressSummary struct {
 	SampleNamespaces    []string
 }
 
-// ProbeAgentEgress inspects Observe agent pods and selecting egress NetworkPolicies.
+// ProbeAgentEgress inspects kprompt workload pods and selecting egress NetworkPolicies.
 // nil means use the default kube implementation.
 type ProbeAgentEgress func(ctx context.Context, kubeCtx string) (AgentEgressSummary, error)
 
@@ -38,7 +38,7 @@ func defaultProbeAgentEgress(ctx context.Context, kubeCtx string) (AgentEgressSu
 
 func summarizeAgentEgress(ctx context.Context, cs kubernetes.Interface) (AgentEgressSummary, error) {
 	pods, err := cs.CoreV1().Pods("").List(ctx, metav1.ListOptions{
-		LabelSelector: agentAppNameLabel,
+		LabelSelector: kpromptWorkloadLabelSelector,
 	})
 	if err != nil {
 		return AgentEgressSummary{}, err
@@ -128,24 +128,24 @@ func networkPolicySelectsPod(np networkingv1.NetworkPolicy, pod corev1.Pod) bool
 func checkAgentEgress(sum AgentEgressSummary, probeErr error) Check {
 	c := Check{
 		ID:       "agent-egress",
-		Name:     "Agent NetworkPolicy",
+		Name:     "Workload NetworkPolicy",
 		Required: false,
 	}
 	if probeErr != nil {
 		c.Status = Skip
-		c.Detail = "could not inspect agent NetworkPolicy posture"
-		c.Hint = "Ensure the current context can list pods/networkpolicies, or skip until the agent is installed"
+		c.Detail = "could not inspect NetworkPolicy posture"
+		c.Hint = "Ensure the current context can list pods/networkpolicies, or skip until charts are installed"
 		return c
 	}
 	if sum.AgentPods == 0 {
 		c.Status = Skip
-		c.Detail = "no Observe agent pods found (label app.kubernetes.io/name=kprompt-agent)"
-		c.Hint = "Install charts/kprompt-agent when you want in-cluster Observe; see docs/security/operator-endpoint-hardening.md"
+		c.Detail = "no kprompt agent/coordinator/operator pods found"
+		c.Hint = "Install charts/kprompt-agent (or coordinator/operator); see docs/security/operator-endpoint-hardening.md"
 		return c
 	}
 
 	var parts []string
-	parts = append(parts, fmt.Sprintf("%d agent pod(s)", sum.AgentPods))
+	parts = append(parts, fmt.Sprintf("%d kprompt pod(s)", sum.AgentPods))
 	if len(sum.SampleNamespaces) > 0 {
 		parts = append(parts, "ns="+strings.Join(sum.SampleNamespaces, ","))
 	}
@@ -166,6 +166,6 @@ func checkAgentEgress(sum AgentEgressSummary, probeErr error) Check {
 
 	c.Status = Warn
 	c.Detail = strings.Join(parts, " · ") + " · " + strings.Join(warns, "; ")
-	c.Hint = "Enable charts/kprompt-agent networkPolicy.enabled with CIDRs — docs/security/operator-endpoint-hardening.md (SEC-007). Do not use hostNetwork."
+	c.Hint = "Enable chart networkPolicy.enabled with CIDRs — docs/security/operator-endpoint-hardening.md (SEC-007). Do not use hostNetwork."
 	return c
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -81,6 +81,7 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 	var checks []Check
 	checks = append(checks, checkConfig(file))
 	checks = append(checks, checkLLM(file))
+	checks = append(checks, checkEndpointURLs(file))
 
 	reg, err := detect(ctx, tools.DetectOptions{
 		Context: kubeCtx,

--- a/internal/doctor/endpoint_urls.go
+++ b/internal/doctor/endpoint_urls.go
@@ -1,0 +1,140 @@
+package doctor
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/kprompt/kprompt/internal/config"
+)
+
+// lookupIP resolves a hostname. Overridden in tests.
+var lookupIP = net.LookupIP
+
+// namedEndpoint is a configured operator URL checked by the private-range advisory.
+type namedEndpoint struct {
+	Name string
+	Raw  string
+}
+
+func collectConfiguredEndpoints(file config.File) []namedEndpoint {
+	r := config.Merge(file, "", "", "", "", false, "")
+	var out []namedEndpoint
+	if u := strings.TrimSpace(r.BaseURL); u != "" {
+		out = append(out, namedEndpoint{Name: "llm.base_url", Raw: u})
+	}
+	if u := strings.TrimSpace(file.Tools.Prometheus.URL); u != "" {
+		out = append(out, namedEndpoint{Name: "tools.prometheus.url", Raw: u})
+	}
+	if u := strings.TrimSpace(file.Tools.Grafana.URL); u != "" {
+		out = append(out, namedEndpoint{Name: "tools.grafana.url", Raw: u})
+	}
+	if u := strings.TrimSpace(file.Tools.OTel.Endpoint); u != "" {
+		out = append(out, namedEndpoint{Name: "tools.otel.endpoint", Raw: u})
+	}
+	return out
+}
+
+func hostFromEndpoint(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("empty")
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("no host in %q", raw)
+	}
+	return host, nil
+}
+
+// isSensitiveIP reports RFC-1918 / ULA / loopback / link-local addresses.
+// Decision A still allows these; doctor only warns.
+func isSensitiveIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
+
+func checkEndpointURLs(file config.File) Check {
+	c := Check{
+		ID:       "endpoint-urls",
+		Name:     "Operator endpoint URLs",
+		Required: false,
+	}
+	eps := collectConfiguredEndpoints(file)
+	if len(eps) == 0 {
+		c.Status = Skip
+		c.Detail = "no base_url / prometheus / grafana / otel endpoints configured"
+		c.Hint = "When set, doctor warns if they resolve to private/link-local/loopback — docs/security/operator-endpoint-hardening.md (SEC-007)"
+		return c
+	}
+
+	var sensitive []string
+	var unresolved []string
+	var okCount int
+	for _, ep := range eps {
+		host, err := hostFromEndpoint(ep.Raw)
+		if err != nil {
+			unresolved = append(unresolved, ep.Name+": parse error")
+			continue
+		}
+		// Literal IP in the URL — no DNS needed.
+		if ip := net.ParseIP(host); ip != nil {
+			if isSensitiveIP(ip) {
+				sensitive = append(sensitive, fmt.Sprintf("%s→%s", ep.Name, ip.String()))
+			} else {
+				okCount++
+			}
+			continue
+		}
+		ips, err := lookupIP(host)
+		if err != nil || len(ips) == 0 {
+			unresolved = append(unresolved, ep.Name)
+			continue
+		}
+		hit := false
+		for _, ip := range ips {
+			if isSensitiveIP(ip) {
+				sensitive = append(sensitive, fmt.Sprintf("%s→%s", ep.Name, ip.String()))
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			okCount++
+		}
+	}
+
+	parts := []string{fmt.Sprintf("%d configured", len(eps))}
+	if okCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d public/resolvable", okCount))
+	}
+	if len(unresolved) > 0 {
+		parts = append(parts, "unresolved="+strings.Join(unresolved, ","))
+	}
+
+	if len(sensitive) == 0 {
+		c.Status = Pass
+		c.Detail = strings.Join(parts, " · ")
+		if len(unresolved) > 0 {
+			c.Status = Warn
+			c.Detail += " · could not resolve some hosts"
+			c.Hint = "Check DNS / spelling; private ranges are OK when operator-owned — pin via NetworkPolicy CIDRs"
+		}
+		return c
+	}
+
+	c.Status = Warn
+	c.Detail = strings.Join(parts, " · ") + " · private/link-local/loopback: " + strings.Join(sensitive, ", ")
+	c.Hint = "Advisory only (SEC-007 Decision A) — ensure NetworkPolicy/CNI allowlists match; see docs/security/operator-endpoint-hardening.md"
+	return c
+}

--- a/internal/doctor/endpoint_urls_test.go
+++ b/internal/doctor/endpoint_urls_test.go
@@ -1,0 +1,90 @@
+package doctor
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/kprompt/kprompt/internal/config"
+)
+
+func TestIsSensitiveIP(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"10.0.0.5", true},
+		{"192.168.1.1", true},
+		{"172.16.0.1", true},
+		{"169.254.1.1", true},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+	}
+	for _, tc := range cases {
+		if got := isSensitiveIP(net.ParseIP(tc.ip)); got != tc.want {
+			t.Fatalf("%s: got %v want %v", tc.ip, got, tc.want)
+		}
+	}
+}
+
+func TestHostFromEndpoint(t *testing.T) {
+	h, err := hostFromEndpoint("https://llm.example.com:8443/v1")
+	if err != nil || h != "llm.example.com" {
+		t.Fatalf("got %q %v", h, err)
+	}
+	h, err = hostFromEndpoint("10.0.0.9:9090")
+	if err != nil || h != "10.0.0.9" {
+		t.Fatalf("otel-style got %q %v", h, err)
+	}
+}
+
+func TestCheckEndpointURLsSkipEmpty(t *testing.T) {
+	c := checkEndpointURLs(config.File{})
+	if c.Status != Skip || c.ID != "endpoint-urls" {
+		t.Fatalf("%+v", c)
+	}
+}
+
+func TestCheckEndpointURLsWarnPrivateLiteral(t *testing.T) {
+	orig := lookupIP
+	lookupIP = func(host string) ([]net.IP, error) {
+		if host == "prom.internal.example" {
+			return []net.IP{net.ParseIP("192.168.50.2")}, nil
+		}
+		return orig(host)
+	}
+	t.Cleanup(func() { lookupIP = orig })
+
+	c := checkEndpointURLs(config.File{
+		BaseURL: "http://10.1.2.3:8080/v1",
+		Tools: config.ToolsFile{
+			Prometheus: config.PrometheusTool{URL: "https://prom.internal.example/"},
+		},
+	})
+	if c.Status != Warn {
+		t.Fatalf("%+v", c)
+	}
+	if !strings.Contains(c.Detail, "llm.base_url") || !strings.Contains(c.Detail, "tools.prometheus.url") {
+		t.Fatalf("detail=%q", c.Detail)
+	}
+	if !strings.Contains(c.Hint, "Decision A") {
+		t.Fatalf("hint=%q", c.Hint)
+	}
+}
+
+func TestCheckEndpointURLsPassPublic(t *testing.T) {
+	orig := lookupIP
+	lookupIP = func(host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("1.1.1.1")}, nil
+	}
+	t.Cleanup(func() { lookupIP = orig })
+
+	c := checkEndpointURLs(config.File{
+		BaseURL: "https://api.openai.com/v1",
+	})
+	if c.Status != Pass {
+		t.Fatalf("%+v", c)
+	}
+}


### PR DESCRIPTION
## Summary
Closes the remaining SEC-007 Decision A follow-ups on #118:

- Helm **`values.schema.json`** for `networkPolicy` on agent / coordinator / operator
- Opt-in egress **NetworkPolicy** baselines on **coordinator** + **operator** charts (agent already had one)
- `kprompt doctor` **`endpoint-urls`** advisory — WARN if `base_url` / Prom / Grafana / OTel resolve to private / link-local / loopback (no hard block)
- **`agent-egress`** now covers agent + coordinator + operator pods
- Docs + chart READMEs + CHANGELOG

Decision A unchanged: no automatic private-URL blocking.

Closes #118.

## Test plan
- [x] `go test ./internal/doctor/`
- [x] `helm lint` on three charts
- [x] Schema rejects `networkPolicy.llmPort=99999`
- [x] `helm template` renders NetworkPolicy when enabled on coordinator/operator
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)