### PR TITLE
feat(investigate): Ingress + Prometheus hops (closes #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to kprompt are documented here. Versions follow [GitHub Rele
 
 ## Unreleased
 
+### Features
+
+- **investigate Ingress + Prometheus** — walk matching Ingress backends; attach Prom metric evidence when configured; mesh stays degraded (#44)
+
 ### Security
 
 - **SEC-007 follow-up** — operator endpoint hardening guide + doctor advisories for workload NetworkPolicy / `hostNetwork` and private-range endpoint URLs; Helm `values.schema.json` + coordinator/operator NetworkPolicy baselines (#118)

--- a/docs/investigate.md
+++ b/docs/investigate.md
@@ -11,28 +11,41 @@ kprompt "investigate api" -n payments
 kprompt "investigate api" -n payments -o json
 ```
 
-Walks (MVP):
+Walks:
 
-1. **Service** (selectors matching the workload) — in **parallel** with the Explain chain (T-090)
-2. **Endpoints** (ready / notReady counts) — fan-out per matching Service
-3. **Deployment → ReplicaSet → Pods** (T-024 explain chain)
-4. **Events ∥ Logs** on the worst pod (independent after pods are known)
+1. **Ingress** (backends whose Services select the workload) — in parallel with Explain / Service / Prom
+2. **Service** (selectors matching the workload) — in **parallel** with the Explain chain (T-090)
+3. **Endpoints** (ready / notReady counts) — fan-out per matching Service
+4. **Deployment → ReplicaSet → Pods** (T-024 explain chain)
+5. **Events ∥ Logs** on the worst pod (independent after pods are known)
+6. **Prometheus** metrics (CPU / memory / restart rate) when `tools.prometheus.url` / `KPROMPT_PROMETHEUS_URL` is set and queries succeed
 
 Root cause + confidence come from findings (CrashLoop / ImagePull / OOM / no ready endpoints). Optional suggested fix still goes through PlanResult → approve (never auto-apply).
 
 Prefer a **loop** (this sequential walk) for one Service/workload. Prefer graph width (fan-out / Coordinator) when signals or namespaces are independent — see [investigation-graph.md](./investigation-graph.md#loop-vs-graph). Confidence and suggested fixes are still bound by [reality anchors](./reality-anchors.md) (hard deny, EvidenceRef, PlanResult — not chat vibes). **Pre-trust (T-089):** after the walk, `internal/pretrust` clamps high confidence without EvidenceRef / contradicting re-read and can withhold approve UX for suggested fixes.
 
-**Edge audit (S-019):** hops with no data edge run concurrently (Explain ∥ Service discovery; Endpoints per Service; Events ∥ Logs). True chains (Deployment → RS → Pods) stay sequential.
+**Edge audit (S-019):** hops with no data edge run concurrently (Explain ∥ Service ∥ Ingress ∥ Prometheus; Endpoints per Service; Events ∥ Logs). True chains (Deployment → RS → Pods) stay sequential.
 
 ## Honest gaps (`degraded`)
 
-MVP lists `ingress`, `mesh`, and `prometheus` in `Investigation.degraded` — those hops are not walked yet (S-004 and later slices).
+| Signal | When listed in `degraded` |
+|--------|---------------------------|
+| `ingress` | Ingress API list failed (or walk skipped) — not when list succeeded with zero matches |
+| `prometheus` | No URL configured, client build failed, or all PromQL queries failed — never invents metrics |
+| `mesh` | Istio / Linkerd VirtualService walk still deferred |
+
+Configure Prometheus:
+
+```bash
+kprompt config set tools.prometheus.url http://prometheus.monitoring.svc:9090
+# or: export KPROMPT_PROMETHEUS_URL=…
+```
 
 ## vs `explain` / `why`
 
 | | `explain` | `why` | `investigate` |
 |--|-----------|-------|----------------|
-| Focus | Deployment → Pods → Events → Logs | Cause tree on one pod/workload | + Service / Endpoints ahead of that chain |
+| Focus | Deployment → Pods → Events → Logs | Cause tree on one pod/workload | + Ingress / Service / Endpoints / optional Prom ahead of that chain |
 | Artifact | explain-lite JSON | `Investigation` (`kprompt.io/v1`) | `Investigation` (`kprompt.io/v1`) |
 | Trigger | generic diagnosis | “why is X pending/crashing” | “investigate X” / root cause / RCA |
 | Shape | short chain | **loop** (usually) | chain + independent fan-out (T-090) |

--- a/internal/investigate/ingress.go
+++ b/internal/investigate/ingress.go
@@ -1,0 +1,156 @@
+package investigate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kprompt/kprompt/internal/cluster"
+	"github.com/kprompt/kprompt/internal/incident"
+)
+
+// ingressHops finds Ingress objects whose backends select Services that match podLabels.
+func (inv *Investigator) ingressHops(ctx context.Context, ns string, podLabels map[string]string) (
+	hops []cluster.ChainStep,
+	findings []incident.Finding,
+	evidence []incident.EvidenceRef,
+	walked bool,
+) {
+	if len(podLabels) == 0 {
+		return nil, nil, nil, false
+	}
+
+	ings, err := inv.Client.NetworkingV1().Ingresses(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		findings = append(findings, incident.Finding{
+			Code:     "IngressListError",
+			Severity: incident.SeverityLow,
+			Title:    "Could not list Ingresses",
+			Message:  err.Error(),
+		})
+		return hops, findings, evidence, false
+	}
+	walked = true
+
+	// Cache Service selectors for backends we care about.
+	svcSel := map[string]map[string]string{}
+	getSel := func(name string) (map[string]string, bool) {
+		if sel, ok := svcSel[name]; ok {
+			return sel, sel != nil
+		}
+		svc, err := inv.Client.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil || svc.Spec.Selector == nil {
+			svcSel[name] = nil
+			return nil, false
+		}
+		svcSel[name] = svc.Spec.Selector
+		return svc.Spec.Selector, true
+	}
+
+	for _, ing := range ings.Items {
+		backends := ingressBackendServices(ing)
+		var matched []string
+		for _, svcName := range backends {
+			sel, ok := getSel(svcName)
+			if !ok || !selectorMatches(sel, podLabels) {
+				continue
+			}
+			matched = append(matched, svcName)
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		hosts := ingressHosts(ing)
+		detail := "backends " + strings.Join(matched, ",")
+		if hosts != "" {
+			detail = hosts + " · " + detail
+		}
+		hops = append(hops, cluster.ChainStep{
+			Level:  "Ingress",
+			Name:   ing.Name,
+			Detail: detail,
+		})
+		evidence = append(evidence, incident.EvidenceRef{
+			Type: incident.EvidenceObject,
+			Resource: &incident.ResourceRef{
+				Kind: "Ingress", Name: ing.Name, Namespace: ns,
+			},
+			Reason:  "Selected",
+			Message: detail,
+			Source:  "kubernetes",
+		})
+		if class := ingressClassName(ing); class != "" {
+			findings = append(findings, incident.Finding{
+				Code:      "IngressAttached",
+				Severity:  incident.SeverityInfo,
+				Title:     "Ingress/" + ing.Name + " routes to workload",
+				Message:   fmt.Sprintf("class=%s · %s", class, detail),
+				Namespace: ns,
+			})
+		}
+	}
+	return hops, findings, evidence, walked
+}
+
+func ingressBackendServices(ing networkingv1.Ingress) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
+		add(ing.Spec.DefaultBackend.Service.Name)
+	}
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, p := range rule.HTTP.Paths {
+			if p.Backend.Service != nil {
+				add(p.Backend.Service.Name)
+			}
+		}
+	}
+	return out
+}
+
+func ingressHosts(ing networkingv1.Ingress) string {
+	var hosts []string
+	seen := map[string]struct{}{}
+	for _, rule := range ing.Spec.Rules {
+		h := strings.TrimSpace(rule.Host)
+		if h == "" {
+			continue
+		}
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+	}
+	if len(hosts) == 0 {
+		return ""
+	}
+	return "hosts " + strings.Join(hosts, ",")
+}
+
+func ingressClassName(ing networkingv1.Ingress) string {
+	if ing.Spec.IngressClassName != nil {
+		return strings.TrimSpace(*ing.Spec.IngressClassName)
+	}
+	if v := strings.TrimSpace(ing.Annotations["kubernetes.io/ingress.class"]); v != "" {
+		return v
+	}
+	return ""
+}

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -1,8 +1,9 @@
-// Package investigate builds multi-hop RCA documents (S-002 · T-080 · T-090).
+// Package investigate builds multi-hop RCA documents (S-002 · T-080 · T-090 · #44).
 //
-// MVP hops: Service → Endpoints → Deployment → ReplicaSet → Pods → Events → Logs.
+// Hops: Ingress (when backends select the workload) → Service → Endpoints →
+// Deployment → ReplicaSet → Pods → Events → Logs, plus optional Prometheus metrics.
 // Independent hops fan out in parallel (S-019); sequential only where a real data edge exists.
-// Ingress / mesh / Prometheus are listed in Investigation.Degraded until later slices.
+// Mesh stays in Investigation.Degraded until a later slice.
 package investigate
 
 import (
@@ -31,12 +32,13 @@ type Request struct {
 
 // Investigator walks related objects and emits an Investigation.
 type Investigator struct {
-	Client kubernetes.Interface
+	Client  kubernetes.Interface
+	Metrics MetricsQuerier // optional; nil → degraded prometheus
 }
 
 // Run performs the multi-hop walk and returns a validated Investigation.
-// Explain (workload chain) and Service/Endpoints discovery fan out when both only need
-// the target identity — no data edge between them (S-019 / T-090).
+// Explain, Service/Ingress discovery, and Prometheus fan out when they only need
+// the target identity — no data edge between them (S-019 / T-090 / #44).
 func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investigation, cluster.ExplainReport, error) {
 	if inv == nil || inv.Client == nil {
 		return incident.Investigation{}, cluster.ExplainReport{}, fmt.Errorf("investigate: client required")
@@ -55,17 +57,24 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 	}
 
 	explainer := &cluster.Explainer{Client: inv.Client}
+	podLabels, _ := inv.workloadSelector(ctx, ns, kind, name)
 
 	var (
-		rep        cluster.ExplainReport
-		explainErr error
-		svcHops    []cluster.ChainStep
+		rep         cluster.ExplainReport
+		explainErr  error
+		svcHops     []cluster.ChainStep
 		svcFindings []incident.Finding
 		svcEvidence []incident.EvidenceRef
+		ingHops     []cluster.ChainStep
+		ingFindings []incident.Finding
+		ingEvidence []incident.EvidenceRef
+		ingWalked   bool
+		metricEv    []incident.EvidenceRef
+		metricsOK   bool
 	)
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(4)
 	go func() {
 		defer wg.Done()
 		rep, explainErr = explainer.Explain(ctx, cluster.ExplainRequest{
@@ -74,11 +83,18 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 	}()
 	go func() {
 		defer wg.Done()
-		podLabels, err := inv.workloadSelector(ctx, ns, kind, name)
-		if err != nil || len(podLabels) == 0 {
+		if len(podLabels) == 0 {
 			return
 		}
 		svcHops, svcFindings, svcEvidence = inv.serviceHops(ctx, ns, podLabels)
+	}()
+	go func() {
+		defer wg.Done()
+		ingHops, ingFindings, ingEvidence, ingWalked = inv.ingressHops(ctx, ns, podLabels)
+	}()
+	go func() {
+		defer wg.Done()
+		metricEv, metricsOK = enrichMetrics(ctx, inv.Metrics, ns, name)
 	}()
 	wg.Wait()
 
@@ -89,13 +105,18 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 	out := incident.NewInvestigation(req.Prompt, ns)
 	out.Target = &incident.ResourceRef{Kind: rep.Kind, Name: rep.Target, Namespace: ns}
 	out.Summary = firstNonEmpty(rep.Summary, fmt.Sprintf("%s/%s status: %s", rep.Kind, rep.Target, rep.Status))
-	out.Degraded = []string{"ingress", "mesh", "prometheus"} // honest MVP gaps
+	out.Degraded = buildDegraded(ingWalked, metricsOK)
 
+	// Ingress ahead of Service/Endpoints in the chain.
 	prependChain(&rep, svcHops...)
+	prependChain(&rep, ingHops...)
 
+	out.Findings = append(out.Findings, ingFindings...)
 	out.Findings = append(out.Findings, svcFindings...)
 	out.Findings = append(out.Findings, mapExplainFindings(rep)...)
+	out.Evidence = append(out.Evidence, ingEvidence...)
 	out.Evidence = append(out.Evidence, svcEvidence...)
+	out.Evidence = append(out.Evidence, metricEv...)
 	out.Evidence = append(out.Evidence, mapExplainEvidence(rep)...)
 	out.Timeline = append([]incident.EvidenceRef(nil), out.Evidence...)
 
@@ -109,6 +130,17 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 		return out, rep, err
 	}
 	return out, rep, nil
+}
+
+func buildDegraded(ingressWalked, metricsOK bool) []string {
+	out := []string{"mesh"} // Istio/Linkerd walk still deferred
+	if !ingressWalked {
+		out = append(out, "ingress")
+	}
+	if !metricsOK {
+		out = append(out, "prometheus")
+	}
+	return out
 }
 
 func (inv *Investigator) serviceHops(ctx context.Context, ns string, podLabels map[string]string) (

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -2,16 +2,21 @@ package investigate
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/kprompt/kprompt/internal/cluster"
 	"github.com/kprompt/kprompt/internal/incident"
+	toolprometheus "github.com/kprompt/kprompt/internal/tools/prometheus"
 )
 
 func TestRunCrashLoopWithServiceNoEndpoints(t *testing.T) {
@@ -105,7 +110,11 @@ func TestRunCrashLoopWithServiceNoEndpoints(t *testing.T) {
 	if doc.Confidence <= 0 {
 		t.Fatalf("confidence: %v", doc.Confidence)
 	}
-	for _, d := range []string{"ingress", "mesh", "prometheus"} {
+	// Ingress listed successfully (none matched) → omit; mesh + prometheus still gaps.
+	if contains(doc.Degraded, "ingress") {
+		t.Fatalf("ingress should not be degraded after successful walk: %v", doc.Degraded)
+	}
+	for _, d := range []string{"mesh", "prometheus"} {
 		if !contains(doc.Degraded, d) {
 			t.Fatalf("degraded missing %s: %v", d, doc.Degraded)
 		}
@@ -234,6 +243,150 @@ func TestRunParallelServiceEndpoints(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRunIngressAttached(t *testing.T) {
+	ns := "payments"
+	labels := map[string]string{"app": "api"}
+	var replicas int32 = 1
+	class := "nginx"
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns, UID: "dep1"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "api", Image: "busybox"}}},
+				},
+			},
+			Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "api-0", Namespace: ns, Labels: labels},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "api", Ready: true,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns},
+			Spec:       corev1.ServiceSpec{Selector: labels, Ports: []corev1.ServicePort{{Port: 80}}},
+		},
+		&networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: "api-ing", Namespace: ns},
+			Spec: networkingv1.IngressSpec{
+				IngressClassName: &class,
+				Rules: []networkingv1.IngressRule{{
+					Host: "api.example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{{
+								Path:     "/",
+								PathType: ptrPathType(networkingv1.PathTypePrefix),
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "api",
+										Port: networkingv1.ServiceBackendPort{Number: 80},
+									},
+								},
+							}},
+						},
+					},
+				}},
+			},
+		},
+	)
+	doc, rep, err := (&Investigator{Client: client}).Run(context.Background(), Request{
+		Name: "api", Namespace: ns, Kind: "Deployment", Prompt: "investigate api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !chainHas(rep, "Ingress", "api-ing") {
+		t.Fatalf("chain missing ingress: %+v", rep.Chain)
+	}
+	if !hasFinding(doc, "IngressAttached") {
+		t.Fatalf("findings: %+v", doc.Findings)
+	}
+	if contains(doc.Degraded, "ingress") {
+		t.Fatalf("ingress should not be degraded: %v", doc.Degraded)
+	}
+	if !contains(doc.Degraded, "mesh") || !contains(doc.Degraded, "prometheus") {
+		t.Fatalf("mesh/prometheus still expected: %v", doc.Degraded)
+	}
+}
+
+func TestRunPrometheusMetrics(t *testing.T) {
+	ns := "payments"
+	labels := map[string]string{"app": "api"}
+	var replicas int32 = 1
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns, UID: "dep1"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "api", Image: "busybox"}}},
+				},
+			},
+			Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "api-0", Namespace: ns, Labels: labels},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	)
+	q := stubMetrics{vals: map[string]float64{
+		"cpu_usage":           0.12,
+		"memory_working_set":  64e6,
+		"restart_rate":        0.01,
+	}}
+	doc, _, err := (&Investigator{Client: client, Metrics: q}).Run(context.Background(), Request{
+		Name: "api", Namespace: ns, Kind: "Deployment",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metrics int
+	for _, e := range doc.Evidence {
+		if e.Type == incident.EvidenceMetric {
+			metrics++
+		}
+	}
+	if metrics < 1 {
+		t.Fatalf("expected metric evidence: %+v", doc.Evidence)
+	}
+	if contains(doc.Degraded, "prometheus") {
+		t.Fatalf("prometheus should not be degraded: %v", doc.Degraded)
+	}
+}
+
+type stubMetrics struct {
+	vals map[string]float64
+}
+
+func (s stubMetrics) Query(_ context.Context, promQL string, _ time.Time) (toolprometheus.Result, error) {
+	for reason, v := range s.vals {
+		if strings.Contains(promQL, reason) ||
+			(reason == "cpu_usage" && strings.Contains(promQL, "container_cpu_usage")) ||
+			(reason == "memory_working_set" && strings.Contains(promQL, "container_memory_working_set")) ||
+			(reason == "restart_rate" && strings.Contains(promQL, "kube_pod_container_status_restarts")) {
+			return toolprometheus.Result{
+				Type:   "vector",
+				Series: []toolprometheus.Series{{Samples: []toolprometheus.Sample{{Value: fmt.Sprintf("%g", v)}}}},
+			}, nil
+		}
+	}
+	return toolprometheus.Result{}, fmt.Errorf("no series")
+}
+
+func ptrPathType(t networkingv1.PathType) *networkingv1.PathType { return &t }
 
 func hasFinding(doc incident.Investigation, code string) bool {
 	for _, f := range doc.Findings {

--- a/internal/investigate/metrics.go
+++ b/internal/investigate/metrics.go
@@ -1,0 +1,91 @@
+package investigate
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kprompt/kprompt/internal/incident"
+	toolprometheus "github.com/kprompt/kprompt/internal/tools/prometheus"
+)
+
+// MetricsQuerier is the optional Prometheus adapter for investigate (issue #44).
+type MetricsQuerier interface {
+	Query(ctx context.Context, promQL string, at time.Time) (toolprometheus.Result, error)
+}
+
+// enrichMetrics attaches metric EvidenceRefs when a Querier is configured.
+// Missing / failed Prom → degraded "prometheus" — never invents values.
+func enrichMetrics(ctx context.Context, q MetricsQuerier, ns, workload string) (
+	evidence []incident.EvidenceRef,
+	ok bool,
+) {
+	if q == nil {
+		return nil, false
+	}
+	wl := strings.TrimSpace(workload)
+	if wl == "" || strings.TrimSpace(ns) == "" {
+		return nil, false
+	}
+	podRE := "^" + regexp.QuoteMeta(wl) + "-.*"
+
+	specs := []struct {
+		reason string
+		unit   string
+		query  string
+	}{
+		{
+			reason: "cpu_usage",
+			unit:   "cores",
+			query: fmt.Sprintf(
+				`sum(rate(container_cpu_usage_seconds_total{namespace=%q,pod=~%q,container!="",container!="POD"}[5m]))`,
+				ns, podRE,
+			),
+		},
+		{
+			reason: "memory_working_set",
+			unit:   "bytes",
+			query: fmt.Sprintf(
+				`sum(container_memory_working_set_bytes{namespace=%q,pod=~%q,container!="",container!="POD"})`,
+				ns, podRE,
+			),
+		},
+		{
+			reason: "restart_rate",
+			unit:   "restarts/s",
+			query: fmt.Sprintf(
+				`sum(rate(kube_pod_container_status_restarts_total{namespace=%q,pod=~%q}[15m]))`,
+				ns, podRE,
+			),
+		},
+	}
+
+	now := time.Now().UTC()
+	for _, spec := range specs {
+		res, err := q.Query(ctx, spec.query, time.Time{})
+		if err != nil {
+			continue
+		}
+		val, has, err := toolprometheus.FirstValue(res)
+		if err != nil || !has {
+			continue
+		}
+		ts := now
+		evidence = append(evidence, incident.EvidenceRef{
+			Type:      incident.EvidenceMetric,
+			Reason:    spec.reason,
+			Message:   fmt.Sprintf("%.4g %s", val, spec.unit),
+			Timestamp: &ts,
+			Source:    "prometheus",
+			URI:       spec.query,
+			Resource: &incident.ResourceRef{
+				Kind:      "Workload",
+				Name:      wl,
+				Namespace: ns,
+			},
+		})
+	}
+	return evidence, len(evidence) > 0
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -724,7 +724,13 @@ func RunWith(ctx context.Context, cfg config.Resolved, out io.Writer, deps Deps)
 			if err != nil {
 				return err
 			}
-			invDoc, rep, err := (&investigate.Investigator{Client: client}).Run(ctx, req)
+			inv := &investigate.Investigator{Client: client}
+			if settings := tools.LoadSettings(config.File{Tools: cfg.Tools}); settings.PrometheusEnabled && settings.PrometheusURL != "" {
+				if pc, err := tools.NewPrometheusClient(settings); err == nil {
+					inv.Metrics = pc
+				}
+			}
+			invDoc, rep, err := inv.Run(ctx, req)
 			if err != nil {
 				return cluster.Friendlier(fmt.Errorf("investigate: %w", err))
 			}


### PR DESCRIPTION
## Summary
Closes #44 — investigate no longer always degrades `ingress` / `prometheus`.

- Walk **Ingress** backends whose Services select the workload; attach hops/findings/evidence
- Attach **Prometheus** metric evidence (CPU / memory / restart rate) when URL is configured and queries succeed
- Omit those keys from `degraded` on success; keep **mesh** degraded with honesty
- Pipeline wires `tools.NewPrometheusClient` from config/env
- Docs: `docs/investigate.md`

## Test plan
- [x] `go test ./internal/investigate/`
- [x] `go test ./internal/pipeline/` (compile/smoke)
- [ ] CI green


Made with [Cursor](https://cursor.com)