### PR TITLE
feat(coordinator): KubeProbe Deployments (closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to kprompt are documented here. Versions follow [GitHub Rele
 
 ### Features
 
+- **Coordinator KubeProbe Deployments** — suspect-ns probe also lists Deployments; Helm probe Role includes `apps/deployments` (#45)
 - **investigate Ingress + Prometheus** — walk matching Ingress backends; attach Prom metric evidence when configured; mesh stays degraded (#44)
 
 ### Security

--- a/charts/kprompt-coordinator/Chart.yaml
+++ b/charts/kprompt-coordinator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kprompt-coordinator
 description: Thin Coordinator HTTP fan-in for kprompt Namespace Agents (AG-037; no mutate)
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.12.0"

--- a/charts/kprompt-coordinator/README.md
+++ b/charts/kprompt-coordinator/README.md
@@ -4,7 +4,7 @@ Thin **Coordinator** HTTP fan-in for [kprompt](https://github.com/kprompt/kpromp
 
 ```text
 kprompt agent coordinator --addr :9090
-kprompt agent coordinator --addr :9090 --probe-kube   # read-only Pods/Events in suspect ns
+kprompt agent coordinator --addr :9090 --probe-kube   # read-only Pods/Events/Deployments in suspect ns
 ```
 
 **Never mutates workloads.** Receives `CoordinatorHandoff`, returns `CoordinatorReply` with merged InvestigationReport v2. Shared Knowledge: `GET /v1/knowledge`; with `knowledge.enabled=true` (default) persists the handoff ring in ConfigMap `kprompt-coordinator-knowledge` (AG-060).
@@ -41,7 +41,7 @@ Ns agents point at the Service:
 | Namespace Agent | **Role** in watch ns | Unchanged — never ClusterRole-by-default |
 | Coordinator | **ServiceAccount only** by default | No ClusterRole; no get/list/watch pods/Secrets cluster-wide |
 | Optional ClusterRole | **off** (`rbac.clusterRole.create=false`) | namespaces get/list only — still no mutate |
-| Optional probe Roles | **off** until `probe.enabled` + `rbac.probeNamespaces` | Pods + Events `get/list` in listed ns only |
+| Optional probe Roles | **off** until `probe.enabled` + `rbac.probeNamespaces` | Pods + Events + Deployments `get/list` in listed ns only |
 
 Do not grant the Coordinator `create/update/patch/delete` on workloads.
 

--- a/charts/kprompt-coordinator/templates/probe-rbac.yaml
+++ b/charts/kprompt-coordinator/templates/probe-rbac.yaml
@@ -13,6 +13,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "events"]
     verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cmd/kprompt/agent.go
+++ b/cmd/kprompt/agent.go
@@ -357,7 +357,7 @@ func newAgentCoordinatorCmd() *cobra.Command {
 and reply with CoordinatorReply.
 
 Never applies/patches/deletes workloads. Optional --probe-kube enables a
-read-only Events/Pods probe of suspectNamespace. Default probe is a no-op.
+read-only Pods/Events/Deployments probe of suspectNamespace. Default probe is a no-op.
 
 Shared Knowledge: GET /v1/knowledge summarizes handoff edges.
 Blast-radius MVP: GET /v1/blast-radius turns those edges into risk-ranked hops.
@@ -471,7 +471,7 @@ Pair with: kprompt agent run … --coordinator-url http://<addr>/v1/handoff`,
 		},
 	}
 	cmd.Flags().StringVar(&addr, "addr", ":9090", "listen address for Coordinator HTTP API")
-	cmd.Flags().BoolVar(&probeKube, "probe-kube", false, "read-only Pods/Events probe of suspectNamespace")
+	cmd.Flags().BoolVar(&probeKube, "probe-kube", false, "read-only Pods/Events/Deployments probe of suspectNamespace")
 	cmd.Flags().StringVar(&kubeCtx, "context", "", "kubeconfig context for --probe-kube / configmap knowledge")
 	cmd.Flags().BoolVar(&inCluster, "in-cluster", false, "use in-cluster config for --probe-kube / configmap knowledge")
 	cmd.Flags().StringVar(&knowledgeBackend, "knowledge-backend", "", "persist Shared Knowledge: file|configmap")

--- a/docs/agent-ops.md
+++ b/docs/agent-ops.md
@@ -84,7 +84,7 @@ All of the above stay **local / in-cluster** — not uploaded to `api.kprompt.ai
 ```bash
 # Laptop / kind
 kprompt agent coordinator --addr :9090
-kprompt agent coordinator --addr :9090 --probe-kube   # read-only suspect-ns probe
+kprompt agent coordinator --addr :9090 --probe-kube   # read-only suspect-ns Pods/Events/Deployments
 kprompt agent coordinator --addr :9090 --knowledge-backend configmap --in-cluster --knowledge-namespace kprompt-system
 kprompt agent coordinator knowledge --url http://127.0.0.1:9090
 
@@ -102,7 +102,7 @@ helm upgrade --install kprompt-coordinator ./charts/kprompt-coordinator \
 | `GET /v1/recent` | In-memory recent handoff records (restart-lossy) |
 | `GET /v1/blast-radius` | Blast-radius MVP hops (`?namespace=` filter; AG-066) |
 | RBAC | SA only by default — **no** ClusterRole unless `rbac.clusterRole.create=true` (namespaces get/list only) |
-| Probe RBAC | With `probe.enabled` + `rbac.probeNamespaces`: Pods/Events `get/list` in listed ns only |
+| Probe RBAC | With `probe.enabled` + `rbac.probeNamespaces`: Pods/Events/Deployments `get/list` in listed ns only |
 | Ns agents | Stay Role-scoped; point `--coordinator-url` at the Service `/v1/handoff` |
 
 ### Worker isolation (AG-069)

--- a/internal/agent/coordinator/probe.go
+++ b/internal/agent/coordinator/probe.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -15,16 +16,18 @@ import (
 )
 
 const (
-	defaultMaxPods   = 20
-	defaultMaxEvents = 30
+	defaultMaxPods        = 20
+	defaultMaxEvents      = 30
+	defaultMaxDeployments = 20
 )
 
-// KubeProbe is a read-only suspect-namespace verifier (AG-050 / ADR-0017).
-// It lists Pods + Events in the suspect namespace only — never mutates.
+// KubeProbe is a read-only suspect-namespace verifier (AG-050 / ADR-0017 / #45).
+// It lists Pods, Events, and Deployments in the suspect namespace only — never mutates.
 type KubeProbe struct {
-	Client    kubernetes.Interface
-	MaxPods   int
-	MaxEvents int
+	Client         kubernetes.Interface
+	MaxPods        int
+	MaxEvents      int
+	MaxDeployments int
 }
 
 func (p *KubeProbe) Probe(ctx context.Context, suspectNamespace string, _ handoff.Envelope) (*incident.InvestigationReport, error) {
@@ -42,6 +45,10 @@ func (p *KubeProbe) Probe(ctx context.Context, suspectNamespace string, _ handof
 	maxEvents := p.MaxEvents
 	if maxEvents <= 0 {
 		maxEvents = defaultMaxEvents
+	}
+	maxDeps := p.MaxDeployments
+	if maxDeps <= 0 {
+		maxDeps = defaultMaxDeployments
 	}
 
 	at := time.Now().UTC()
@@ -130,11 +137,44 @@ func (p *KubeProbe) Probe(ctx context.Context, suspectNamespace string, _ handof
 		}
 	}
 
+	depUnavailable := 0
+	deps, err := p.Client.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{Limit: int64(maxDeps)})
+	if err != nil {
+		rep.Unknowns = append(rep.Unknowns, fmt.Sprintf("probe: list deployments in %s: %v", ns, err))
+		rep.Degraded = append(rep.Degraded, "deployments")
+	} else {
+		for i, dep := range deps.Items {
+			if i >= maxDeps {
+				break
+			}
+			desired := int32(1)
+			if dep.Spec.Replicas != nil {
+				desired = *dep.Spec.Replicas
+			}
+			msg := fmt.Sprintf("desired=%d ready=%d unavailable=%d", desired, dep.Status.ReadyReplicas, dep.Status.UnavailableReplicas)
+			unhealthy := dep.Status.UnavailableReplicas > 0 || (desired > 0 && dep.Status.ReadyReplicas < desired)
+			if unhealthy {
+				depUnavailable++
+				rep.Evidence = append(rep.Evidence, incident.EvidenceRef{
+					Type:      incident.EvidenceObject,
+					Resource:  &incident.ResourceRef{Kind: "Deployment", Name: dep.Name, Namespace: ns, APIVersion: "apps/v1"},
+					Reason:    deploymentProbeReason(dep),
+					Message:   msg,
+					Source:    "coordinator-kube-probe",
+					Timestamp: &at,
+				})
+			}
+			if i < 3 {
+				facts = append(facts, "deploy/"+dep.Name+":"+msg)
+			}
+		}
+	}
+
 	total := len(pods.Items)
-	rep.Facts = fmt.Sprintf("pods=%d notReady=%d restarts=%d; %s", total, notReady, restarts, strings.Join(facts, "; "))
+	rep.Facts = fmt.Sprintf("pods=%d notReady=%d restarts=%d depUnavailable=%d; %s", total, notReady, restarts, depUnavailable, strings.Join(facts, "; "))
 	switch {
-	case notReady > 0 || restarts > 0:
-		rep.Summary = fmt.Sprintf("namespace %q: %d/%d pods not ready, cumulative restarts=%d", ns, notReady, total, restarts)
+	case notReady > 0 || restarts > 0 || depUnavailable > 0:
+		rep.Summary = fmt.Sprintf("namespace %q: %d/%d pods not ready, cumulative restarts=%d, unavailable deployments=%d", ns, notReady, total, restarts, depUnavailable)
 		rep.Confidence = 0.55
 		rep.Severity = incident.SeverityMedium
 		rep.Hypotheses = []incident.Hypothesis{{
@@ -159,15 +199,22 @@ func (p *KubeProbe) Probe(ctx context.Context, suspectNamespace string, _ handof
 	// so Merge never treats a healthy narrative-only report as soft-agree.
 	if len(rep.Evidence) == 0 && len(rep.Unknowns) == 0 {
 		rep.Evidence = append(rep.Evidence, incident.EvidenceRef{
-			Type:     incident.EvidenceObject,
-			Resource: &incident.ResourceRef{Kind: "Namespace", Name: ns, Namespace: ns, APIVersion: "v1"},
-			Reason:   "ProbeSnapshot",
-			Message:  rep.Facts,
-			Source:   "coordinator-kube-probe",
+			Type:      incident.EvidenceObject,
+			Resource:  &incident.ResourceRef{Kind: "Namespace", Name: ns, Namespace: ns, APIVersion: "v1"},
+			Reason:    "ProbeSnapshot",
+			Message:   rep.Facts,
+			Source:    "coordinator-kube-probe",
 			Timestamp: &at,
 		})
 	}
 	return &rep, nil
+}
+
+func deploymentProbeReason(dep appsv1.Deployment) string {
+	if dep.Status.UnavailableReplicas > 0 {
+		return "UnavailableReplicas"
+	}
+	return "NotFullyReady"
 }
 
 func podReady(pod corev1.Pod) bool {

--- a/internal/agent/coordinator/probe_test.go
+++ b/internal/agent/coordinator/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -64,6 +65,47 @@ func TestKubeProbeEmptyNS(t *testing.T) {
 	_, err := p.Probe(context.Background(), "", handoff.Envelope{})
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestKubeProbeDeploymentUnavailable(t *testing.T) {
+	var replicas int32 = 2
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "api-0", Namespace: "platform"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "platform"},
+			Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+			Status: appsv1.DeploymentStatus{
+				ReadyReplicas: 0, UnavailableReplicas: 2,
+			},
+		},
+	)
+	rep, err := (&KubeProbe{Client: client}).Probe(context.Background(), "platform", handoff.Envelope{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range rep.Evidence {
+		if e.Resource != nil && e.Resource.Kind == "Deployment" && e.Resource.Name == "api" {
+			found = true
+			if e.Reason != "UnavailableReplicas" {
+				t.Fatalf("reason=%q", e.Reason)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected Deployment evidence: %+v", rep.Evidence)
+	}
+	if !strings.Contains(rep.Summary, "unavailable deployments") {
+		t.Fatalf("summary=%q", rep.Summary)
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #45. Live `KubeProbe` already existed (`--probe-kube` + Helm `probe.enabled`); this finishes the acceptance surface:

- Suspect-ns probe now lists **Deployments** (unavailable → EvidenceRef)
- Helm probe Role: `apps/deployments` get/list
- Docs / CLI help updated; chart `0.2.2`
- Soft-fail + `mutateAttempted=false` unchanged; probe stays opt-in (NopProbe default without `--probe-kube`)

## Test plan
- [x] `go test ./internal/agent/coordinator/`
- [ ] CI green


Made with [Cursor](https://cursor.com)