### PR TITLE
feat(gitops): Flux per-resource drift inventory (closes #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to kprompt are documented here. Versions follow [GitHub Rele
 
 ### Features
 
+- **Flux per-resource drift inventory** — OutOfSync Kustomizations expand `status.inventory.entries` into `Drift.ResourceOutOfSync` (capped); missing inventory degrades honestly (#48)
 - **Coordinator KubeProbe Deployments** — suspect-ns probe also lists Deployments; Helm probe Role includes `apps/deployments` (#45)
 - **investigate Ingress + Prometheus** — walk matching Ingress backends; attach Prom metric evidence when configured; mesh stays degraded (#44)
 

--- a/docs/drift.md
+++ b/docs/drift.md
@@ -23,7 +23,7 @@ silently, and `-o json` stays report-only.
 |------|----------------|
 | `Drift.OutOfSync` | Flux Ready=False / Argo `sync.status=OutOfSync` on an app |
 | `Drift.Unhealthy` | Synced app with non-Healthy health (guidance; not auto-synced) |
-| `Drift.ResourceOutOfSync` | Argo `status.resources[]` entries that are not Synced (capped) |
+| `Drift.ResourceOutOfSync` | Argo `status.resources[]` not Synced, or Flux `status.inventory.entries` while the Kustomization is OutOfSync (capped) |
 | `Drift.GitOpsMissing` | Neither Flux nor Argo CD CRDs detected (honest degrade) |
 
 ```bash
@@ -43,6 +43,8 @@ guidance when you want Git review before reconcile.
 
 - Drift is GitOps controller truth (sync/health inventory), not a full
   live-vs-manifest deep diff of every object field.
-- Flux MVP does not expand per-resource inventory (Argo `status.resources` only).
+- **Argo:** per-resource rows come from `status.resources` (non-Synced only).
+- **Flux Kustomization:** when OutOfSync, expands `status.inventory.entries` (managed set) and labels them OutOfSync — Flux has no per-resource sync bit. Missing inventory → `degraded: flux-inventory`.
+- **Flux HelmRelease:** no Kustomization-style inventory API — app-level OutOfSync/Unhealthy only (degrade if expanded).
 - Manual changes that GitOps has already overwritten will not appear as drift.
 - Prefer `kprompt "gitops status"` for a compact table without Investigation codes.

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -37,7 +37,8 @@ type Analyzer struct {
 	Config *rest.Config
 	// Status overrides SummarizeStatus (tests).
 	Status func(ctx context.Context, cfg *rest.Config, req gitops.StatusRequest) (gitops.StatusReport, error)
-	// Resources lists per-app drifted child resources (Argo status.resources). Optional.
+	// Resources lists per-app drifted child resources (Argo status.resources /
+	// Flux status.inventory). Optional.
 	Resources func(ctx context.Context, cfg *rest.Config, app gitops.AppStatus) ([]gitops.ResourceDrift, error)
 }
 
@@ -149,14 +150,18 @@ func (a *Analyzer) Run(ctx context.Context, req Request) (incident.Investigation
 			})
 		}
 
-		if syncOO && strings.EqualFold(app.Engine, "argocd") {
+		if syncOO && (strings.EqualFold(app.Engine, "argocd") || strings.EqualFold(app.Engine, "argo") || strings.EqualFold(app.Engine, "flux")) {
 			resFn := a.Resources
 			if resFn == nil {
 				resFn = gitops.ListResourceDrifts
 			}
 			drifts, err := resFn(ctx, a.Config, app)
 			if err != nil {
-				out.Degraded = appendUnique(out.Degraded, "argocd-resources")
+				key := "argocd-resources"
+				if strings.EqualFold(app.Engine, "flux") {
+					key = "flux-inventory"
+				}
+				out.Degraded = appendUnique(out.Degraded, key)
 				continue
 			}
 			for _, d := range drifts {
@@ -170,6 +175,7 @@ func (a *Analyzer) Run(ctx context.Context, req Request) (incident.Investigation
 					Name:       d.Name,
 					Namespace:  d.Namespace,
 				}
+				src := app.Engine
 				out.Findings = append(out.Findings, incident.Finding{
 					Code:      CodeResourceDrift,
 					Severity:  incident.SeverityMedium,
@@ -178,7 +184,7 @@ func (a *Analyzer) Run(ctx context.Context, req Request) (incident.Investigation
 					Namespace: firstNonEmpty(d.Namespace, app.Namespace),
 					Evidence: []incident.EvidenceRef{{
 						Type:     incident.EvidenceGitOps,
-						Source:   "argocd",
+						Source:   src,
 						Resource: rref,
 						Message:  fmt.Sprintf("parent=%s/%s", app.Namespace, app.Name),
 					}},

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -98,6 +98,79 @@ func TestRunResourceDrifts(t *testing.T) {
 	}
 }
 
+func TestRunFluxInventoryResourceDrifts(t *testing.T) {
+	a := &Analyzer{
+		Config: &rest.Config{Host: "https://example"},
+		Status: func(context.Context, *rest.Config, gitops.StatusRequest) (gitops.StatusReport, error) {
+			return gitops.StatusReport{
+				Apps: []gitops.AppStatus{
+					{Engine: "flux", Kind: "Kustomization", Name: "apps", Namespace: "flux-system", Sync: "OutOfSync", Health: "Degraded"},
+				},
+			}, nil
+		},
+		Resources: func(_ context.Context, _ *rest.Config, app gitops.AppStatus) ([]gitops.ResourceDrift, error) {
+			if app.Engine != "flux" {
+				t.Fatalf("engine=%s", app.Engine)
+			}
+			return []gitops.ResourceDrift{{
+				Kind: "Deployment", Name: "api", Namespace: "shop", Status: "OutOfSync", APIVersion: "apps/v1",
+			}}, nil
+		},
+	}
+	inv, err := a.Run(context.Background(), Request{Prompt: "check flux drift"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	codes := map[string]int{}
+	for _, f := range inv.Findings {
+		codes[f.Code]++
+		if f.Code == CodeResourceDrift && f.Evidence[0].Source != "flux" {
+			t.Fatalf("source=%q", f.Evidence[0].Source)
+		}
+	}
+	if codes[CodeOutOfSync] != 1 || codes[CodeResourceDrift] != 1 {
+		t.Fatalf("codes=%v", codes)
+	}
+}
+
+func TestRunFluxInventoryDegrade(t *testing.T) {
+	a := &Analyzer{
+		Config: &rest.Config{Host: "https://example"},
+		Status: func(context.Context, *rest.Config, gitops.StatusRequest) (gitops.StatusReport, error) {
+			return gitops.StatusReport{
+				Apps: []gitops.AppStatus{
+					{Engine: "flux", Kind: "Kustomization", Name: "apps", Namespace: "flux-system", Sync: "OutOfSync"},
+				},
+			}, nil
+		},
+		Resources: func(context.Context, *rest.Config, gitops.AppStatus) ([]gitops.ResourceDrift, error) {
+			return nil, errFluxInventoryUnavailable
+		},
+	}
+	inv, err := a.Run(context.Background(), Request{Prompt: "drift"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(inv.Degraded, "flux-inventory") {
+		t.Fatalf("degraded=%v", inv.Degraded)
+	}
+}
+
+type unavailableErr string
+
+func (e unavailableErr) Error() string { return string(e) }
+
+const errFluxInventoryUnavailable = unavailableErr("flux inventory unavailable")
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestRunClean(t *testing.T) {
 	a := &Analyzer{
 		Config: &rest.Config{Host: "https://example"},

--- a/internal/tools/gitops/resources.go
+++ b/internal/tools/gitops/resources.go
@@ -11,7 +11,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// ResourceDrift is one Argo CD status.resources entry that is not Synced.
+// ResourceDrift is one drifted (or parent-out-of-sync inventory) child resource.
+// Argo: status.resources entries that are not Synced.
+// Flux: status.inventory.entries while the Kustomization is OutOfSync (Flux has no
+// per-resource sync flag — inventory is the managed set; inherit OutOfSync).
 type ResourceDrift struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	Kind       string `json:"kind"`
@@ -22,11 +25,20 @@ type ResourceDrift struct {
 }
 
 // ListResourceDrifts returns OutOfSync (or otherwise non-Synced) child resources
-// from an Argo CD Application. Flux apps return nil (no per-resource inventory in MVP).
+// for Argo CD Applications, or inventory entries for out-of-sync Flux Kustomizations.
 func ListResourceDrifts(ctx context.Context, cfg *rest.Config, app AppStatus) ([]ResourceDrift, error) {
-	if !strings.EqualFold(app.Engine, "argocd") && !strings.EqualFold(app.Engine, "argo") {
+	engine := strings.ToLower(strings.TrimSpace(app.Engine))
+	switch engine {
+	case "argocd", "argo":
+		return listArgoResourceDrifts(ctx, cfg, app)
+	case "flux":
+		return listFluxResourceDrifts(ctx, cfg, app)
+	default:
 		return nil, nil
 	}
+}
+
+func listArgoResourceDrifts(ctx context.Context, cfg *rest.Config, app AppStatus) ([]ResourceDrift, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("gitops resource drifts: rest config is nil")
 	}
@@ -38,10 +50,29 @@ func ListResourceDrifts(ctx context.Context, cfg *rest.Config, app AppStatus) ([
 	if err != nil {
 		return nil, err
 	}
-	return resourceDriftsFromApp(obj), nil
+	return resourceDriftsFromArgoApp(obj), nil
 }
 
-func resourceDriftsFromApp(obj *unstructured.Unstructured) []ResourceDrift {
+func listFluxResourceDrifts(ctx context.Context, cfg *rest.Config, app AppStatus) ([]ResourceDrift, error) {
+	// HelmRelease has no Kustomization-style inventory.entries — degrade honestly.
+	if kind := strings.TrimSpace(app.Kind); kind != "" && !strings.EqualFold(kind, FluxKind) && !strings.EqualFold(kind, "Kustomization") {
+		return nil, fmt.Errorf("flux inventory unavailable for kind %s (Kustomization status.inventory only)", kind)
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("gitops resource drifts: rest config is nil")
+	}
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := dc.Resource(KustomizationGVR).Namespace(app.Namespace).Get(ctx, app.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return resourceDriftsFromFluxKustomization(obj)
+}
+
+func resourceDriftsFromArgoApp(obj *unstructured.Unstructured) []ResourceDrift {
 	if obj == nil {
 		return nil
 	}
@@ -88,4 +119,91 @@ func resourceDriftsFromApp(obj *unstructured.Unstructured) []ResourceDrift {
 		})
 	}
 	return out
+}
+
+// resourceDriftsFromFluxKustomization expands status.inventory.entries when present.
+// Returns an error when the inventory field is absent so callers can degrade honestly.
+func resourceDriftsFromFluxKustomization(obj *unstructured.Unstructured) ([]ResourceDrift, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("flux inventory unavailable")
+	}
+	inv, found, err := unstructured.NestedMap(obj.Object, "status", "inventory")
+	if err != nil || !found || inv == nil {
+		return nil, fmt.Errorf("flux inventory unavailable")
+	}
+	raw, ok, _ := unstructured.NestedSlice(inv, "entries")
+	if !ok {
+		// inventory present but empty/malformed entries — treat as empty list, not degrade
+		return nil, nil
+	}
+	out := make([]ResourceDrift, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := m["id"].(string)
+		ver, _ := m["v"].(string)
+		ns, name, group, kind, ok := parseFluxInventoryID(id)
+		if !ok {
+			continue
+		}
+		api := strings.TrimSpace(ver)
+		if group != "" {
+			if api != "" {
+				api = group + "/" + api
+			} else {
+				api = group
+			}
+		}
+		out = append(out, ResourceDrift{
+			APIVersion: api,
+			Kind:       kind,
+			Name:       name,
+			Namespace:  ns,
+			// Flux has no per-resource sync bit; parent OutOfSync → inherit.
+			Status: "OutOfSync",
+		})
+	}
+	return out, nil
+}
+
+// parseFluxInventoryID parses SSA ObjMetadata ids: namespace_name_group_kind
+// (empty group yields a double underscore before kind).
+func parseFluxInventoryID(id string) (ns, name, group, kind string, ok bool) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", "", "", false
+	}
+	// kind
+	i := strings.LastIndex(id, "_")
+	if i < 0 {
+		return "", "", "", "", false
+	}
+	kind = id[i+1:]
+	rest := id[:i]
+	// group (may be empty)
+	i = strings.LastIndex(rest, "_")
+	if i < 0 {
+		return "", "", "", "", false
+	}
+	group = rest[i+1:]
+	rest = rest[:i]
+	// name
+	i = strings.LastIndex(rest, "_")
+	if i < 0 {
+		// cluster-scoped with empty ns encoded as leading underscore already consumed
+		// rest is name only when format was _name__Kind → after stripping kind+group, rest="_name" or "name"
+		name = strings.TrimPrefix(rest, "_")
+		if name == "" || kind == "" {
+			return "", "", "", "", false
+		}
+		return "", name, group, kind, true
+	}
+	name = rest[i+1:]
+	ns = rest[:i]
+	if name == "" || kind == "" {
+		return "", "", "", "", false
+	}
+	return ns, name, group, kind, true
 }

--- a/internal/tools/gitops/resources_test.go
+++ b/internal/tools/gitops/resources_test.go
@@ -6,16 +6,30 @@ import (
 	"testing"
 )
 
-func TestListResourceDriftsSkipsNonArgoEngines(t *testing.T) {
-	got, err := ListResourceDrifts(context.Background(), nil, AppStatus{Engine: "flux"})
+func TestListResourceDriftsUnknownEngine(t *testing.T) {
+	got, err := ListResourceDrifts(context.Background(), nil, AppStatus{Engine: "other"})
 	if err != nil || got != nil {
 		t.Fatalf("got=%+v err=%v", got, err)
 	}
 }
 
-func TestListResourceDriftsNilConfig(t *testing.T) {
+func TestListResourceDriftsNilConfigArgo(t *testing.T) {
 	_, err := ListResourceDrifts(context.Background(), nil, AppStatus{Engine: "argocd"})
 	if err == nil || !strings.Contains(err.Error(), "rest config is nil") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestListResourceDriftsNilConfigFlux(t *testing.T) {
+	_, err := ListResourceDrifts(context.Background(), nil, AppStatus{Engine: "flux", Kind: FluxKind})
+	if err == nil || !strings.Contains(err.Error(), "rest config is nil") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestListResourceDriftsFluxHelmReleaseDegrades(t *testing.T) {
+	_, err := ListResourceDrifts(context.Background(), nil, AppStatus{Engine: "flux", Kind: "HelmRelease"})
+	if err == nil || !strings.Contains(err.Error(), "inventory unavailable") {
 		t.Fatalf("err=%v", err)
 	}
 }

--- a/internal/tools/gitops/status_test.go
+++ b/internal/tools/gitops/status_test.go
@@ -56,8 +56,64 @@ func TestResourceDriftsFromApp(t *testing.T) {
 			},
 		},
 	}}
-	got := resourceDriftsFromApp(obj)
+	got := resourceDriftsFromArgoApp(obj)
 	if len(got) != 1 || got[0].Name != "api" || got[0].APIVersion != "apps/v1" {
 		t.Fatalf("%+v", got)
+	}
+}
+
+func TestResourceDriftsFromFluxInventory(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "apps", "namespace": "flux-system"},
+		"status": map[string]any{
+			"inventory": map[string]any{
+				"entries": []any{
+					map[string]any{"id": "shop_api_apps_Deployment", "v": "v1"},
+					map[string]any{"id": "shop_api__Service", "v": "v1"},
+					map[string]any{"id": "_widgets.example.com_apiextensions.k8s.io_CustomResourceDefinition", "v": "v1"},
+				},
+			},
+		},
+	}}
+	got, err := resourceDriftsFromFluxKustomization(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("%+v", got)
+	}
+	if got[0].Kind != "Deployment" || got[0].Name != "api" || got[0].Namespace != "shop" || got[0].APIVersion != "apps/v1" {
+		t.Fatalf("dep=%+v", got[0])
+	}
+	if got[1].Kind != "Service" || got[1].Name != "api" || got[1].APIVersion != "v1" {
+		t.Fatalf("svc=%+v", got[1])
+	}
+	if got[2].Kind != "CustomResourceDefinition" || got[2].Name != "widgets.example.com" || got[2].Namespace != "" {
+		t.Fatalf("crd=%+v", got[2])
+	}
+	if got[0].Status != "OutOfSync" {
+		t.Fatalf("status=%q", got[0].Status)
+	}
+}
+
+func TestResourceDriftsFromFluxMissingInventory(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "apps", "namespace": "flux-system"},
+		"status":   map[string]any{},
+	}}
+	_, err := resourceDriftsFromFluxKustomization(obj)
+	if err == nil || !strings.Contains(err.Error(), "inventory unavailable") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestParseFluxInventoryID(t *testing.T) {
+	ns, name, group, kind, ok := parseFluxInventoryID("payments_redis_apps_Deployment")
+	if !ok || ns != "payments" || name != "redis" || group != "apps" || kind != "Deployment" {
+		t.Fatalf("%q %q %q %q %v", ns, name, group, kind, ok)
+	}
+	ns, name, group, kind, ok = parseFluxInventoryID("_cluster-ns__Namespace")
+	if !ok || ns != "" || name != "cluster-ns" || group != "" || kind != "Namespace" {
+		t.Fatalf("cluster %q %q %q %q %v", ns, name, group, kind, ok)
 	}
 }


### PR DESCRIPTION
## Summary
Closes #48 — Flux parity with Argo child-resource drift.

- OutOfSync **Kustomization** → capped `status.inventory.entries` as `Drift.ResourceOutOfSync` (Flux has no per-resource sync bit; inherit OutOfSync)
- Missing inventory → `degraded: flux-inventory`
- **HelmRelease** → honest “inventory unavailable” (no Kustomization-style API)
- Unit fixtures + `docs/drift.md` limits updated

## Test plan
- [x] `go test ./internal/tools/gitops/ ./internal/drift/`
- [ ] CI green


Made with [Cursor](https://cursor.com)