### PR TITLE
feat(investigate): walk Istio VirtualService mesh hop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to kprompt are documented here. Versions follow [GitHub Rele
 
 ## Unreleased
 
+### Features
+
+- **investigate VirtualService mesh hop** — walk Istio VirtualServices whose destinations match workload Services; omit `mesh` from `degraded` when the API was queried (or CRD absent)
+
 ## [v0.12.1](https://github.com/kprompt/kprompt/releases/tag/v0.12.1) — 2026-08-29
 
 Security hardening + RCA / GitOps honesty follow-ups since v0.12.0.

--- a/docs/investigate.md
+++ b/docs/investigate.md
@@ -13,18 +13,19 @@ kprompt "investigate api" -n payments -o json
 
 Walks:
 
-1. **Ingress** (backends whose Services select the workload) — in parallel with Explain / Service / Prom
-2. **Service** (selectors matching the workload) — in **parallel** with the Explain chain (T-090)
-3. **Endpoints** (ready / notReady counts) — fan-out per matching Service
-4. **Deployment → ReplicaSet → Pods** (T-024 explain chain)
-5. **Events ∥ Logs** on the worst pod (independent after pods are known)
-6. **Prometheus** metrics (CPU / memory / restart rate) when `tools.prometheus.url` / `KPROMPT_PROMETHEUS_URL` is set and queries succeed
+1. **VirtualService** (Istio destinations whose hosts match Services selecting the workload) — when a dynamic client is available
+2. **Ingress** (backends whose Services select the workload) — in parallel with Explain / Service / Prom / mesh
+3. **Service** (selectors matching the workload) — in **parallel** with the Explain chain (T-090)
+4. **Endpoints** (ready / notReady counts) — fan-out per matching Service
+5. **Deployment → ReplicaSet → Pods** (T-024 explain chain)
+6. **Events ∥ Logs** on the worst pod (independent after pods are known)
+7. **Prometheus** metrics (CPU / memory / restart rate) when `tools.prometheus.url` / `KPROMPT_PROMETHEUS_URL` is set and queries succeed
 
 Root cause + confidence come from findings (CrashLoop / ImagePull / OOM / no ready endpoints). Optional suggested fix still goes through PlanResult → approve (never auto-apply).
 
 Prefer a **loop** (this sequential walk) for one Service/workload. Prefer graph width (fan-out / Coordinator) when signals or namespaces are independent — see [investigation-graph.md](./investigation-graph.md#loop-vs-graph). Confidence and suggested fixes are still bound by [reality anchors](./reality-anchors.md) (hard deny, EvidenceRef, PlanResult — not chat vibes). **Pre-trust (T-089):** after the walk, `internal/pretrust` clamps high confidence without EvidenceRef / contradicting re-read and can withhold approve UX for suggested fixes.
 
-**Edge audit (S-019):** hops with no data edge run concurrently (Explain ∥ Service ∥ Ingress ∥ Prometheus; Endpoints per Service; Events ∥ Logs). True chains (Deployment → RS → Pods) stay sequential.
+**Edge audit (S-019):** hops with no data edge run concurrently (Explain ∥ Service ∥ Ingress ∥ VirtualService ∥ Prometheus; Endpoints per Service; Events ∥ Logs). True chains (Deployment → RS → Pods) stay sequential.
 
 ## Honest gaps (`degraded`)
 
@@ -32,7 +33,7 @@ Prefer a **loop** (this sequential walk) for one Service/workload. Prefer graph 
 |--------|---------------------------|
 | `ingress` | Ingress API list failed (or walk skipped) — not when list succeeded with zero matches |
 | `prometheus` | No URL configured, client build failed, or all PromQL queries failed — never invents metrics |
-| `mesh` | Istio / Linkerd VirtualService walk still deferred |
+| `mesh` | No dynamic client, or VirtualService list failed (not when CRD absent / zero matches) |
 
 Configure Prometheus:
 
@@ -45,7 +46,7 @@ kprompt config set tools.prometheus.url http://prometheus.monitoring.svc:9090
 
 | | `explain` | `why` | `investigate` |
 |--|-----------|-------|----------------|
-| Focus | Deployment → Pods → Events → Logs | Cause tree on one pod/workload | + Ingress / Service / Endpoints / optional Prom ahead of that chain |
+| Focus | Deployment → Pods → Events → Logs | Cause tree on one pod/workload | + VS / Ingress / Service / Endpoints / optional Prom ahead of that chain |
 | Artifact | explain-lite JSON | `Investigation` (`kprompt.io/v1`) | `Investigation` (`kprompt.io/v1`) |
 | Trigger | generic diagnosis | “why is X pending/crashing” | “investigate X” / root cause / RCA |
 | Shape | short chain | **loop** (usually) | chain + independent fan-out (T-090) |

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -1,9 +1,8 @@
 // Package investigate builds multi-hop RCA documents (S-002 · T-080 · T-090 · #44).
 //
-// Hops: Ingress (when backends select the workload) → Service → Endpoints →
-// Deployment → ReplicaSet → Pods → Events → Logs, plus optional Prometheus metrics.
-// Independent hops fan out in parallel (S-019); sequential only where a real data edge exists.
-// Mesh stays in Investigation.Degraded until a later slice.
+// Hops: VirtualService (Istio destinations matching workload Services) → Ingress →
+// Service → Endpoints → Deployment → ReplicaSet → Pods → Events → Logs, plus
+// optional Prometheus metrics. Independent hops fan out in parallel (S-019).
 package investigate
 
 import (
@@ -15,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kprompt/kprompt/internal/cluster"
@@ -33,11 +33,12 @@ type Request struct {
 // Investigator walks related objects and emits an Investigation.
 type Investigator struct {
 	Client  kubernetes.Interface
-	Metrics MetricsQuerier // optional; nil → degraded prometheus
+	Metrics MetricsQuerier    // optional; nil → degraded prometheus
+	Dynamic dynamic.Interface // optional; nil → degraded mesh
 }
 
 // Run performs the multi-hop walk and returns a validated Investigation.
-// Explain, Service/Ingress discovery, and Prometheus fan out when they only need
+// Explain, Service/Ingress/mesh discovery, and Prometheus fan out when they only need
 // the target identity — no data edge between them (S-019 / T-090 / #44).
 func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investigation, cluster.ExplainReport, error) {
 	if inv == nil || inv.Client == nil {
@@ -60,21 +61,25 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 	podLabels, _ := inv.workloadSelector(ctx, ns, kind, name)
 
 	var (
-		rep         cluster.ExplainReport
-		explainErr  error
-		svcHops     []cluster.ChainStep
-		svcFindings []incident.Finding
-		svcEvidence []incident.EvidenceRef
-		ingHops     []cluster.ChainStep
-		ingFindings []incident.Finding
-		ingEvidence []incident.EvidenceRef
-		ingWalked   bool
-		metricEv    []incident.EvidenceRef
-		metricsOK   bool
+		rep          cluster.ExplainReport
+		explainErr   error
+		svcHops      []cluster.ChainStep
+		svcFindings  []incident.Finding
+		svcEvidence  []incident.EvidenceRef
+		ingHops      []cluster.ChainStep
+		ingFindings  []incident.Finding
+		ingEvidence  []incident.EvidenceRef
+		ingWalked    bool
+		meshHops     []cluster.ChainStep
+		meshFindings []incident.Finding
+		meshEvidence []incident.EvidenceRef
+		meshWalked   bool
+		metricEv     []incident.EvidenceRef
+		metricsOK    bool
 	)
 
 	var wg sync.WaitGroup
-	wg.Add(4)
+	wg.Add(5)
 	go func() {
 		defer wg.Done()
 		rep, explainErr = explainer.Explain(ctx, cluster.ExplainRequest{
@@ -94,6 +99,10 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 	}()
 	go func() {
 		defer wg.Done()
+		meshHops, meshFindings, meshEvidence, meshWalked = inv.meshHops(ctx, ns, podLabels)
+	}()
+	go func() {
+		defer wg.Done()
 		metricEv, metricsOK = enrichMetrics(ctx, inv.Metrics, ns, name)
 	}()
 	wg.Wait()
@@ -105,15 +114,18 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 	out := incident.NewInvestigation(req.Prompt, ns)
 	out.Target = &incident.ResourceRef{Kind: rep.Kind, Name: rep.Target, Namespace: ns}
 	out.Summary = firstNonEmpty(rep.Summary, fmt.Sprintf("%s/%s status: %s", rep.Kind, rep.Target, rep.Status))
-	out.Degraded = buildDegraded(ingWalked, metricsOK)
+	out.Degraded = buildDegraded(ingWalked, metricsOK, meshWalked)
 
-	// Ingress ahead of Service/Endpoints in the chain.
+	// VirtualService → Ingress → Service/Endpoints ahead of explain chain.
 	prependChain(&rep, svcHops...)
 	prependChain(&rep, ingHops...)
+	prependChain(&rep, meshHops...)
 
+	out.Findings = append(out.Findings, meshFindings...)
 	out.Findings = append(out.Findings, ingFindings...)
 	out.Findings = append(out.Findings, svcFindings...)
 	out.Findings = append(out.Findings, mapExplainFindings(rep)...)
+	out.Evidence = append(out.Evidence, meshEvidence...)
 	out.Evidence = append(out.Evidence, ingEvidence...)
 	out.Evidence = append(out.Evidence, svcEvidence...)
 	out.Evidence = append(out.Evidence, metricEv...)
@@ -132,8 +144,11 @@ func (inv *Investigator) Run(ctx context.Context, req Request) (incident.Investi
 	return out, rep, nil
 }
 
-func buildDegraded(ingressWalked, metricsOK bool) []string {
-	out := []string{"mesh"} // Istio/Linkerd walk still deferred
+func buildDegraded(ingressWalked, metricsOK, meshWalked bool) []string {
+	var out []string
+	if !meshWalked {
+		out = append(out, "mesh")
+	}
 	if !ingressWalked {
 		out = append(out, "ingress")
 	}
@@ -370,11 +385,11 @@ func mapExplainEvidence(rep cluster.ExplainReport) []incident.EvidenceRef {
 func rootCauseFrom(rep cluster.ExplainReport, findings []incident.Finding) (string, float64) {
 	priority := []string{"OOMKilled", "ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff", "NoReadyEndpoints"}
 	conf := map[string]float64{
-		"OOMKilled":          0.85,
-		"ImagePullBackOff":   0.85,
-		"ErrImagePull":       0.85,
-		"CrashLoopBackOff":   0.80,
-		"NoReadyEndpoints":   0.80,
+		"OOMKilled":        0.85,
+		"ImagePullBackOff": 0.85,
+		"ErrImagePull":     0.85,
+		"CrashLoopBackOff": 0.80,
+		"NoReadyEndpoints": 0.80,
 	}
 	byCode := map[string]incident.Finding{}
 	for _, f := range findings {

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -110,7 +110,8 @@ func TestRunCrashLoopWithServiceNoEndpoints(t *testing.T) {
 	if doc.Confidence <= 0 {
 		t.Fatalf("confidence: %v", doc.Confidence)
 	}
-	// Ingress listed successfully (none matched) → omit; mesh + prometheus still gaps.
+	// Ingress listed successfully (none matched) → omit; mesh + prometheus still gaps
+	// when Dynamic / Metrics are unset.
 	if contains(doc.Degraded, "ingress") {
 		t.Fatalf("ingress should not be degraded after successful walk: %v", doc.Degraded)
 	}
@@ -343,9 +344,9 @@ func TestRunPrometheusMetrics(t *testing.T) {
 		},
 	)
 	q := stubMetrics{vals: map[string]float64{
-		"cpu_usage":           0.12,
-		"memory_working_set":  64e6,
-		"restart_rate":        0.01,
+		"cpu_usage":          0.12,
+		"memory_working_set": 64e6,
+		"restart_rate":       0.01,
 	}}
 	doc, _, err := (&Investigator{Client: client, Metrics: q}).Run(context.Background(), Request{
 		Name: "api", Namespace: ns, Kind: "Deployment",

--- a/internal/investigate/mesh.go
+++ b/internal/investigate/mesh.go
@@ -1,0 +1,233 @@
+package investigate
+
+import (
+	"context"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kprompt/kprompt/internal/cluster"
+	"github.com/kprompt/kprompt/internal/incident"
+	toolistio "github.com/kprompt/kprompt/internal/tools/istio"
+)
+
+// meshHops finds Istio VirtualServices whose route destinations target Services
+// that select the workload. walked=true when the mesh API was queried (or absent).
+func (inv *Investigator) meshHops(ctx context.Context, ns string, podLabels map[string]string) (
+	hops []cluster.ChainStep,
+	findings []incident.Finding,
+	evidence []incident.EvidenceRef,
+	walked bool,
+) {
+	if inv.Dynamic == nil {
+		return nil, nil, nil, false
+	}
+	if len(podLabels) == 0 {
+		return nil, nil, nil, true
+	}
+
+	svcNames, err := inv.matchingServiceNames(ctx, ns, podLabels)
+	if err != nil {
+		findings = append(findings, incident.Finding{
+			Code:     "MeshServiceListError",
+			Severity: incident.SeverityLow,
+			Title:    "Could not list Services for mesh match",
+			Message:  err.Error(),
+		})
+		return hops, findings, evidence, false
+	}
+	if len(svcNames) == 0 {
+		return nil, nil, nil, true
+	}
+
+	list, err := inv.Dynamic.Resource(toolistio.VirtualServiceGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || isNoMatchGVR(err) {
+			// No VirtualService API — mesh not installed; treat as walked empty.
+			return nil, nil, nil, true
+		}
+		findings = append(findings, incident.Finding{
+			Code:     "VirtualServiceListError",
+			Severity: incident.SeverityLow,
+			Title:    "Could not list VirtualServices",
+			Message:  err.Error(),
+		})
+		return hops, findings, evidence, false
+	}
+	walked = true
+
+	for i := range list.Items {
+		vs := &list.Items[i]
+		dests := virtualServiceDestinationHosts(vs)
+		var matched []string
+		for _, host := range dests {
+			if svc := matchMeshHostToService(host, ns, svcNames); svc != "" {
+				matched = append(matched, svc)
+			}
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		matched = uniqueStrings(matched)
+		hosts, _, _ := unstructured.NestedStringSlice(vs.Object, "spec", "hosts")
+		detail := "destinations " + strings.Join(matched, ",")
+		if len(hosts) > 0 {
+			detail = "hosts " + strings.Join(hosts, ",") + " · " + detail
+		}
+		if isCanaryVS(vs) {
+			detail += " · weighted/canary routes"
+		}
+		hops = append(hops, cluster.ChainStep{
+			Level:  "VirtualService",
+			Name:   vs.GetName(),
+			Detail: detail,
+		})
+		evidence = append(evidence, incident.EvidenceRef{
+			Type: incident.EvidenceObject,
+			Resource: &incident.ResourceRef{
+				Kind: "VirtualService", Name: vs.GetName(), Namespace: ns,
+				APIVersion: toolistio.VirtualServiceGroup + "/v1beta1",
+			},
+			Reason:  "Selected",
+			Message: detail,
+			Source:  "istio",
+		})
+		findings = append(findings, incident.Finding{
+			Code:      "VirtualServiceAttached",
+			Severity:  incident.SeverityInfo,
+			Title:     "VirtualService/" + vs.GetName() + " routes to workload",
+			Message:   detail,
+			Namespace: ns,
+		})
+	}
+	return hops, findings, evidence, walked
+}
+
+func (inv *Investigator) matchingServiceNames(ctx context.Context, ns string, podLabels map[string]string) ([]string, error) {
+	svcs, err := inv.Client.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, svc := range svcs.Items {
+		if svc.Spec.Selector == nil || len(svc.Spec.Selector) == 0 {
+			continue
+		}
+		if selectorMatches(svc.Spec.Selector, podLabels) {
+			names = append(names, svc.Name)
+		}
+	}
+	return names, nil
+}
+
+func virtualServiceDestinationHosts(vs *unstructured.Unstructured) []string {
+	var hosts []string
+	seen := map[string]struct{}{}
+	add := func(h string) {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			return
+		}
+		if _, ok := seen[h]; ok {
+			return
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+	}
+	for _, block := range []string{"http", "tcp"} {
+		routes, ok, _ := unstructured.NestedSlice(vs.Object, "spec", block)
+		if !ok {
+			continue
+		}
+		for _, raw := range routes {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			route, ok, _ := unstructured.NestedSlice(m, "route")
+			if !ok {
+				continue
+			}
+			for _, r := range route {
+				rm, ok := r.(map[string]any)
+				if !ok {
+					continue
+				}
+				if h, ok, _ := unstructured.NestedString(rm, "destination", "host"); ok {
+					add(h)
+				}
+			}
+		}
+	}
+	return hosts
+}
+
+func matchMeshHostToService(host, ns string, svcNames []string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return ""
+	}
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	for _, name := range svcNames {
+		n := strings.ToLower(name)
+		candidates := []string{
+			n,
+			n + "." + strings.ToLower(ns),
+			n + "." + strings.ToLower(ns) + ".svc",
+			n + "." + strings.ToLower(ns) + ".svc.cluster.local",
+		}
+		for _, c := range candidates {
+			if host == c {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+func isCanaryVS(vs *unstructured.Unstructured) bool {
+	for _, block := range []string{"http", "tcp"} {
+		routes, ok, _ := unstructured.NestedSlice(vs.Object, "spec", block)
+		if !ok {
+			continue
+		}
+		for _, raw := range routes {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			route, ok, _ := unstructured.NestedSlice(m, "route")
+			if ok && len(route) > 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isNoMatchGVR(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "could not find the requested resource") ||
+		strings.Contains(msg, "the server could not find the requested resource")
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/investigate/mesh_test.go
+++ b/internal/investigate/mesh_test.go
@@ -1,0 +1,175 @@
+package investigate
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	metafake "k8s.io/client-go/testing"
+
+	toolistio "github.com/kprompt/kprompt/internal/tools/istio"
+)
+
+func TestRunVirtualServiceAttached(t *testing.T) {
+	ns := "payments"
+	labels := map[string]string{"app": "api"}
+	var replicas int32 = 1
+	client := kubefake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns, UID: "dep1"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "api", Image: "busybox"}}},
+				},
+			},
+			Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "api-0", Namespace: ns, Labels: labels},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "api", Ready: true,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns},
+			Spec:       corev1.ServiceSpec{Selector: labels, Ports: []corev1.ServicePort{{Port: 80}}},
+		},
+		&corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns},
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}},
+			}},
+		},
+	)
+
+	gvr := toolistio.VirtualServiceGVR
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "VirtualServiceList"},
+	)
+	dyn.PrependReactor("list", "virtualservices", func(action metafake.Action) (bool, runtime.Object, error) {
+		list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "networking.istio.io/v1beta1",
+				"kind":       "VirtualService",
+				"metadata":   map[string]any{"name": "api-vs", "namespace": ns},
+				"spec": map[string]any{
+					"hosts": []any{"api.payments.svc.cluster.local"},
+					"http": []any{
+						map[string]any{
+							"route": []any{
+								map[string]any{
+									"destination": map[string]any{"host": "api"},
+									"weight":      int64(100),
+								},
+							},
+						},
+					},
+				},
+			},
+		}}}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: gvr.Group, Version: gvr.Version, Kind: "VirtualServiceList",
+		})
+		return true, list, nil
+	})
+
+	doc, rep, err := (&Investigator{Client: client, Dynamic: dyn}).Run(context.Background(), Request{
+		Name: "api", Namespace: ns, Kind: "Deployment", Prompt: "investigate api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !chainHas(rep, "VirtualService", "api-vs") {
+		t.Fatalf("chain missing VirtualService: %+v", rep.Chain)
+	}
+	if !hasFinding(doc, "VirtualServiceAttached") {
+		t.Fatalf("findings: %+v", doc.Findings)
+	}
+	if contains(doc.Degraded, "mesh") {
+		t.Fatalf("mesh should not be degraded after walk: %v", doc.Degraded)
+	}
+	if !contains(doc.Degraded, "prometheus") {
+		t.Fatalf("prometheus still expected: %v", doc.Degraded)
+	}
+}
+
+func TestRunMeshWalkedEmptyWhenNoCRD(t *testing.T) {
+	ns := "payments"
+	labels := map[string]string{"app": "api"}
+	var replicas int32 = 1
+	client := kubefake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns, UID: "dep1"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "api", Image: "busybox"}}},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: ns},
+			Spec:       corev1.ServiceSpec{Selector: labels},
+		},
+	)
+	gvr := toolistio.VirtualServiceGVR
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "VirtualServiceList"},
+	)
+	dyn.PrependReactor("list", "virtualservices", func(action metafake.Action) (bool, runtime.Object, error) {
+		return true, nil, errNoMatchGVR{}
+	})
+
+	doc, _, err := (&Investigator{Client: client, Dynamic: dyn}).Run(context.Background(), Request{
+		Name: "api", Namespace: ns, Kind: "Deployment",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(doc.Degraded, "mesh") {
+		t.Fatalf("absent CRD should clear mesh degraded: %v", doc.Degraded)
+	}
+}
+
+type errNoMatchGVR struct{}
+
+func (errNoMatchGVR) Error() string {
+	return "no matches for kind VirtualService in version networking.istio.io/v1beta1"
+}
+
+func TestMatchMeshHostToService(t *testing.T) {
+	svcs := []string{"api"}
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"api", "api"},
+		{"api.payments", "api"},
+		{"api.payments.svc", "api"},
+		{"api.payments.svc.cluster.local", "api"},
+		{"api.payments.svc.cluster.local:8080", "api"},
+		{"other", ""},
+		{"api.other", ""},
+	}
+	for _, tc := range cases {
+		if got := matchMeshHostToService(tc.host, "payments", svcs); got != tc.want {
+			t.Fatalf("%q: got %q want %q", tc.host, got, tc.want)
+		}
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -725,6 +725,13 @@ func RunWith(ctx context.Context, cfg config.Resolved, out io.Writer, deps Deps)
 				return err
 			}
 			inv := &investigate.Investigator{Client: client}
+			dyn := deps.Dynamic
+			if dyn == nil && restCfg != nil {
+				if d, err := cluster.DynamicForConfig(restCfg); err == nil {
+					dyn = d
+				}
+			}
+			inv.Dynamic = dyn
 			if settings := tools.LoadSettings(config.File{Tools: cfg.Tools}); settings.PrometheusEnabled && settings.PrometheusURL != "" {
 				if pc, err := tools.NewPrometheusClient(settings); err == nil {
 					inv.Metrics = pc


### PR DESCRIPTION
## Summary
- Walk Istio `VirtualService` destinations that target Services selecting the investigated workload (fan-out with Ingress / Service / Prom).
- Omit `mesh` from `Investigation.degraded` when the mesh API was queried or the CRD is absent; keep it when `Dynamic` is unset or list fails.
- Wire `dynamic.Interface` from pipeline `restCfg` / deps into `investigate.Investigator`.

## Test plan
- [x] `go test ./internal/investigate/ ./internal/pipeline/`
- [ ] CI green on this PR
- [ ] Optional: cluster with Istio — `kprompt "investigate api" -n payments -o json` shows VirtualService hop / no `mesh` in degraded


Made with [Cursor](https://cursor.com)