### PR TITLE
feat(impact): walk Istio VirtualService reverse deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to kprompt are documented here. Versions follow [GitHub Rele
 ### Features
 
 - **investigate VirtualService mesh hop** — walk Istio VirtualServices whose destinations match workload Services; omit `mesh` from `degraded` when the API was queried (or CRD absent)
+- **impact VirtualService routes** — reverse-deps include Istio VirtualServices targeting the Service (or Deployment-selected Services); same honest `mesh` degrade rules
 
 ## [v0.12.1](https://github.com/kprompt/kprompt/releases/tag/v0.12.1) — 2026-08-29
 

--- a/docs/impact.md
+++ b/docs/impact.md
@@ -21,6 +21,7 @@ For a **Service**, kprompt reports:
 - Deployments whose container env / command / args statically reference the Service
 - backend Deployments selected by the Service
 - Ingress objects that route to the Service
+- VirtualService objects whose destinations target the Service (when a dynamic client is available)
 
 For a **Deployment**, kprompt reports:
 
@@ -28,6 +29,7 @@ For a **Deployment**, kprompt reports:
 - Deployments that statically reference those Services
 - HPAs that scale it
 - PodDisruptionBudgets that protect its pods
+- VirtualServices that route to those selected Services (when a dynamic client is available)
 
 The result uses the versioned `Investigation` JSON contract:
 
@@ -44,7 +46,7 @@ Secret values and it does not claim complete runtime coverage.
 `degraded` includes:
 
 - `otel` — runtime caller edges are unavailable in the static walk
-- `mesh` — service-mesh traffic edges are not walked yet
+- `mesh` — no dynamic client, or VirtualService list failed (not when CRD absent / zero matches)
 
 No findings means “no static references found,” not “nobody calls this.”
 `impact` never mutates and never asks for approval.

--- a/internal/impact/impact.go
+++ b/internal/impact/impact.go
@@ -15,6 +15,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kprompt/kprompt/internal/cluster"
@@ -31,7 +32,8 @@ type Request struct {
 
 // Analyzer walks reverse dependency edges and emits an Investigation document.
 type Analyzer struct {
-	Client kubernetes.Interface
+	Client  kubernetes.Interface
+	Dynamic dynamic.Interface // optional; when set, VirtualService routes are walked
 }
 
 // Run returns static consumers plus workload relationships for the target.
@@ -122,15 +124,24 @@ func (a *Analyzer) serviceImpact(ctx context.Context, ns, name string, out *inci
 		}
 	}
 
-	out.Summary = fmt.Sprintf(
+	vsRoutes, meshWalked := a.attachVirtualServices(ctx, ns, []string{name}, out)
+	if meshWalked {
+		clearDegraded(out, "mesh")
+	}
+
+	summary := fmt.Sprintf(
 		"Impact for Service/%s in %s: %d static consumer(s), %d backend Deployment(s), %d Ingress route(s)",
 		name, ns, consumers, backends, routes,
 	)
-	out.Confidence = staticConfidence(consumers, routes)
+	if meshWalked {
+		summary += fmt.Sprintf(", %d VirtualService route(s)", vsRoutes)
+	}
+	out.Summary = summary
+	out.Confidence = staticConfidence(consumers, routes+vsRoutes)
 	if len(out.Findings) == 0 {
 		addFinding(out, "Impact.NoneFound", incident.SeverityInfo,
 			"No static consumers found",
-			"No Deployment env/command/args or Ingress backend referenced this Service; runtime callers need OTel",
+			"No Deployment env/command/args, Ingress backend, or VirtualService destination referenced this Service; runtime callers need OTel",
 			"Service", name, ns, "Target")
 	}
 	return nil
@@ -220,15 +231,24 @@ func (a *Analyzer) deploymentImpact(ctx context.Context, ns, name string, out *i
 		}
 	}
 
-	out.Summary = fmt.Sprintf(
+	vsRoutes, meshWalked := a.attachVirtualServices(ctx, ns, selectedServices, out)
+	if meshWalked {
+		clearDegraded(out, "mesh")
+	}
+
+	summary := fmt.Sprintf(
 		"Impact for Deployment/%s in %s: %d consumer Deployment(s) via %d Service(s), %d HPA(s), %d PDB(s)",
 		name, ns, len(consumerNames), len(selectedServices), hpaCount, pdbCount,
 	)
-	out.Confidence = staticConfidence(len(consumerNames), len(selectedServices))
+	if meshWalked {
+		summary += fmt.Sprintf(", %d VirtualService route(s)", vsRoutes)
+	}
+	out.Summary = summary
+	out.Confidence = staticConfidence(len(consumerNames), len(selectedServices)+vsRoutes)
 	if len(out.Findings) == 0 {
 		addFinding(out, "Impact.NoneFound", incident.SeverityInfo,
 			"No static consumers found",
-			"No Service, Deployment reference, HPA, or PDB relationship was found; runtime callers need OTel",
+			"No Service, Deployment reference, HPA, PDB, or VirtualService relationship was found; runtime callers need OTel",
 			"Deployment", name, ns, "Target")
 	}
 	return nil

--- a/internal/impact/impact_test.go
+++ b/internal/impact/impact_test.go
@@ -42,6 +42,9 @@ func TestServiceImpactFindsConsumersBackendsAndIngress(t *testing.T) {
 	if got.Confidence != 0.8 {
 		t.Fatalf("confidence=%v", got.Confidence)
 	}
+	if !contains(got.Degraded, "mesh") || !contains(got.Degraded, "otel") {
+		t.Fatalf("mesh/otel still expected without Dynamic: %v", got.Degraded)
+	}
 }
 
 func TestDeploymentImpactFindsServiceConsumersHPAAndPDB(t *testing.T) {

--- a/internal/impact/mesh.go
+++ b/internal/impact/mesh.go
@@ -1,0 +1,100 @@
+package impact
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kprompt/kprompt/internal/incident"
+	toolistio "github.com/kprompt/kprompt/internal/tools/istio"
+)
+
+// attachVirtualServices adds Impact.VirtualService findings for VS destinations
+// matching svcNames. walked=true when the mesh API was queried (or CRD absent).
+func (a *Analyzer) attachVirtualServices(ctx context.Context, ns string, svcNames []string, out *incident.Investigation) (routes int, walked bool) {
+	if a == nil || a.Dynamic == nil {
+		return 0, false
+	}
+	if len(svcNames) == 0 {
+		return 0, true
+	}
+
+	list, err := a.Dynamic.Resource(toolistio.VirtualServiceGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || toolistio.IsNoMatchGVR(err) {
+			return 0, true
+		}
+		return 0, false
+	}
+	walked = true
+
+	for i := range list.Items {
+		vs := &list.Items[i]
+		dests := toolistio.VirtualServiceDestinationHosts(vs)
+		var matched []string
+		for _, host := range dests {
+			if svc := toolistio.MatchHostToService(host, ns, svcNames); svc != "" {
+				matched = append(matched, svc)
+			}
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		matched = uniqueStrings(matched)
+		hosts, _, _ := unstructured.NestedStringSlice(vs.Object, "spec", "hosts")
+		detail := "destinations " + strings.Join(matched, ",")
+		if len(hosts) > 0 {
+			detail = "hosts " + strings.Join(hosts, ",") + " · " + detail
+		}
+		if toolistio.IsCanaryVirtualService(vs) {
+			detail += " · weighted/canary routes"
+		}
+		routes++
+		titleSvc := matched[0]
+		if len(matched) > 1 {
+			titleSvc = strings.Join(matched, ",")
+		}
+		addFinding(out, "Impact.VirtualService", incident.SeverityInfo,
+			fmt.Sprintf("VirtualService/%s routes to Service/%s", vs.GetName(), titleSvc),
+			detail,
+			"VirtualService", vs.GetName(), ns, "RoutesTo")
+		if n := len(out.Evidence); n > 0 {
+			last := &out.Evidence[n-1]
+			last.Source = "istio"
+			if last.Resource != nil {
+				last.Resource.APIVersion = toolistio.VirtualServiceGroup + "/v1beta1"
+			}
+		}
+	}
+	return routes, walked
+}
+
+func clearDegraded(out *incident.Investigation, value string) {
+	if out == nil {
+		return
+	}
+	next := out.Degraded[:0]
+	for _, d := range out.Degraded {
+		if d != value {
+			next = append(next, d)
+		}
+	}
+	out.Degraded = next
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/impact/mesh_test.go
+++ b/internal/impact/mesh_test.go
@@ -1,0 +1,81 @@
+package impact
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	metafake "k8s.io/client-go/testing"
+
+	toolistio "github.com/kprompt/kprompt/internal/tools/istio"
+)
+
+func TestServiceImpactVirtualService(t *testing.T) {
+	client := kubefake.NewSimpleClientset(
+		service("redis", map[string]string{"app": "redis"}),
+		deployment("redis", map[string]string{"app": "redis"}, nil),
+	)
+	gvr := toolistio.VirtualServiceGVR
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "VirtualServiceList"},
+	)
+	dyn.PrependReactor("list", "virtualservices", func(action metafake.Action) (bool, runtime.Object, error) {
+		list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{{
+			Object: map[string]any{
+				"apiVersion": "networking.istio.io/v1beta1",
+				"kind":       "VirtualService",
+				"metadata":   map[string]any{"name": "redis-vs", "namespace": "payments"},
+				"spec": map[string]any{
+					"hosts": []any{"redis"},
+					"http": []any{
+						map[string]any{
+							"route": []any{
+								map[string]any{
+									"destination": map[string]any{"host": "redis.payments.svc"},
+									"weight":      int64(100),
+								},
+							},
+						},
+					},
+				},
+			},
+		}}}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: gvr.Group, Version: gvr.Version, Kind: "VirtualServiceList",
+		})
+		return true, list, nil
+	})
+
+	got, err := (&Analyzer{Client: client, Dynamic: dyn}).Run(context.Background(), Request{
+		Name: "redis", Namespace: "payments", Kind: "Service",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireFinding(t, got, "Impact.VirtualService", "VirtualService/redis-vs routes to Service/redis")
+	if !strings.Contains(got.Summary, "1 VirtualService route(s)") {
+		t.Fatalf("summary=%q", got.Summary)
+	}
+	for _, d := range got.Degraded {
+		if d == "mesh" {
+			t.Fatalf("mesh should not be degraded: %v", got.Degraded)
+		}
+	}
+	if !contains(got.Degraded, "otel") {
+		t.Fatalf("otel still expected: %v", got.Degraded)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/investigate/mesh.go
+++ b/internal/investigate/mesh.go
@@ -44,8 +44,7 @@ func (inv *Investigator) meshHops(ctx context.Context, ns string, podLabels map[
 
 	list, err := inv.Dynamic.Resource(toolistio.VirtualServiceGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) || isNoMatchGVR(err) {
-			// No VirtualService API — mesh not installed; treat as walked empty.
+		if apierrors.IsNotFound(err) || toolistio.IsNoMatchGVR(err) {
 			return nil, nil, nil, true
 		}
 		findings = append(findings, incident.Finding{
@@ -60,10 +59,10 @@ func (inv *Investigator) meshHops(ctx context.Context, ns string, podLabels map[
 
 	for i := range list.Items {
 		vs := &list.Items[i]
-		dests := virtualServiceDestinationHosts(vs)
+		dests := toolistio.VirtualServiceDestinationHosts(vs)
 		var matched []string
 		for _, host := range dests {
-			if svc := matchMeshHostToService(host, ns, svcNames); svc != "" {
+			if svc := toolistio.MatchHostToService(host, ns, svcNames); svc != "" {
 				matched = append(matched, svc)
 			}
 		}
@@ -76,7 +75,7 @@ func (inv *Investigator) meshHops(ctx context.Context, ns string, podLabels map[
 		if len(hosts) > 0 {
 			detail = "hosts " + strings.Join(hosts, ",") + " · " + detail
 		}
-		if isCanaryVS(vs) {
+		if toolistio.IsCanaryVirtualService(vs) {
 			detail += " · weighted/canary routes"
 		}
 		hops = append(hops, cluster.ChainStep{
@@ -120,103 +119,6 @@ func (inv *Investigator) matchingServiceNames(ctx context.Context, ns string, po
 		}
 	}
 	return names, nil
-}
-
-func virtualServiceDestinationHosts(vs *unstructured.Unstructured) []string {
-	var hosts []string
-	seen := map[string]struct{}{}
-	add := func(h string) {
-		h = strings.TrimSpace(h)
-		if h == "" {
-			return
-		}
-		if _, ok := seen[h]; ok {
-			return
-		}
-		seen[h] = struct{}{}
-		hosts = append(hosts, h)
-	}
-	for _, block := range []string{"http", "tcp"} {
-		routes, ok, _ := unstructured.NestedSlice(vs.Object, "spec", block)
-		if !ok {
-			continue
-		}
-		for _, raw := range routes {
-			m, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			route, ok, _ := unstructured.NestedSlice(m, "route")
-			if !ok {
-				continue
-			}
-			for _, r := range route {
-				rm, ok := r.(map[string]any)
-				if !ok {
-					continue
-				}
-				if h, ok, _ := unstructured.NestedString(rm, "destination", "host"); ok {
-					add(h)
-				}
-			}
-		}
-	}
-	return hosts
-}
-
-func matchMeshHostToService(host, ns string, svcNames []string) string {
-	host = strings.TrimSpace(strings.ToLower(host))
-	if host == "" {
-		return ""
-	}
-	if i := strings.IndexByte(host, ':'); i >= 0 {
-		host = host[:i]
-	}
-	for _, name := range svcNames {
-		n := strings.ToLower(name)
-		candidates := []string{
-			n,
-			n + "." + strings.ToLower(ns),
-			n + "." + strings.ToLower(ns) + ".svc",
-			n + "." + strings.ToLower(ns) + ".svc.cluster.local",
-		}
-		for _, c := range candidates {
-			if host == c {
-				return name
-			}
-		}
-	}
-	return ""
-}
-
-func isCanaryVS(vs *unstructured.Unstructured) bool {
-	for _, block := range []string{"http", "tcp"} {
-		routes, ok, _ := unstructured.NestedSlice(vs.Object, "spec", block)
-		if !ok {
-			continue
-		}
-		for _, raw := range routes {
-			m, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			route, ok, _ := unstructured.NestedSlice(m, "route")
-			if ok && len(route) > 1 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func isNoMatchGVR(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "no matches for kind") ||
-		strings.Contains(msg, "could not find the requested resource") ||
-		strings.Contains(msg, "the server could not find the requested resource")
 }
 
 func uniqueStrings(in []string) []string {

--- a/internal/investigate/mesh_test.go
+++ b/internal/investigate/mesh_test.go
@@ -168,7 +168,7 @@ func TestMatchMeshHostToService(t *testing.T) {
 		{"api.other", ""},
 	}
 	for _, tc := range cases {
-		if got := matchMeshHostToService(tc.host, "payments", svcs); got != tc.want {
+		if got := toolistio.MatchHostToService(tc.host, "payments", svcs); got != tc.want {
 			t.Fatalf("%q: got %q want %q", tc.host, got, tc.want)
 		}
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -896,7 +896,15 @@ func RunWith(ctx context.Context, cfg config.Resolved, out io.Writer, deps Deps)
 			if err != nil {
 				return err
 			}
-			invDoc, err := (&impact.Analyzer{Client: client}).Run(ctx, req)
+			ana := &impact.Analyzer{Client: client}
+			dyn := deps.Dynamic
+			if dyn == nil && restCfg != nil {
+				if d, err := cluster.DynamicForConfig(restCfg); err == nil {
+					dyn = d
+				}
+			}
+			ana.Dynamic = dyn
+			invDoc, err := ana.Run(ctx, req)
 			if err != nil {
 				return cluster.Friendlier(fmt.Errorf("impact: %w", err))
 			}

--- a/internal/tools/istio/hosts.go
+++ b/internal/tools/istio/hosts.go
@@ -1,0 +1,114 @@
+package istio
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// VirtualServiceDestinationHosts returns unique destination.host values from http/tcp routes.
+func VirtualServiceDestinationHosts(vs *unstructured.Unstructured) []string {
+	if vs == nil {
+		return nil
+	}
+	var hosts []string
+	seen := map[string]struct{}{}
+	add := func(h string) {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			return
+		}
+		if _, ok := seen[h]; ok {
+			return
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+	}
+	for _, block := range []string{"http", "tcp"} {
+		routes, ok, _ := unstructured.NestedSlice(vs.Object, "spec", block)
+		if !ok {
+			continue
+		}
+		for _, raw := range routes {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			route, ok, _ := unstructured.NestedSlice(m, "route")
+			if !ok {
+				continue
+			}
+			for _, r := range route {
+				rm, ok := r.(map[string]any)
+				if !ok {
+					continue
+				}
+				if h, ok, _ := unstructured.NestedString(rm, "destination", "host"); ok {
+					add(h)
+				}
+			}
+		}
+	}
+	return hosts
+}
+
+// MatchHostToService returns the Service name when host matches short or FQDN forms in ns.
+func MatchHostToService(host, ns string, svcNames []string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return ""
+	}
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	for _, name := range svcNames {
+		n := strings.ToLower(name)
+		candidates := []string{
+			n,
+			n + "." + strings.ToLower(ns),
+			n + "." + strings.ToLower(ns) + ".svc",
+			n + "." + strings.ToLower(ns) + ".svc.cluster.local",
+		}
+		for _, c := range candidates {
+			if host == c {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// IsCanaryVirtualService is true when any http/tcp route block has multiple destinations.
+func IsCanaryVirtualService(vs *unstructured.Unstructured) bool {
+	if vs == nil {
+		return false
+	}
+	for _, block := range []string{"http", "tcp"} {
+		routes, ok, _ := unstructured.NestedSlice(vs.Object, "spec", block)
+		if !ok {
+			continue
+		}
+		for _, raw := range routes {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			route, ok, _ := unstructured.NestedSlice(m, "route")
+			if ok && len(route) > 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsNoMatchGVR reports discovery errors when a CRD/GVR is not installed.
+func IsNoMatchGVR(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "could not find the requested resource") ||
+		strings.Contains(msg, "the server could not find the requested resource")
+}


### PR DESCRIPTION
## Summary
- `impact` walks Istio VirtualServices whose destinations match the target Service (or Deployment-selected Services).
- Omit `mesh` from `degraded` when the mesh API was queried or the CRD is absent (same honesty model as investigate #188).
- Extract shared VS host helpers into `internal/tools/istio` for investigate + impact.

## Test plan
- [x] `go test ./internal/impact/ ./internal/investigate/ ./internal/tools/istio/ ./internal/pipeline/`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)